### PR TITLE
Add missing dependency for browserify

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "stream-browserify": "~1.0.0",
     "readable-stream": "~1.0.26"
   },
   "devDependencies": {


### PR DESCRIPTION
stream-browserify isn't included by default – this is required to make bl work in the browser.

Thanks! :)
