### PR TITLE
Only load the duplex readable-stream

### DIFF
--- a/bl.js
+++ b/bl.js
@@ -1,4 +1,4 @@
-var DuplexStream = require('readable-stream').Duplex
+var DuplexStream = require('readable-stream/duplex')
   , util         = require('util')
 
 function BufferList (callback) {


### PR DESCRIPTION
This change reduces the size in browserify by a couple of KB