### PR TITLE
[ci] fix 0.8 build and test 0.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 language: node_js
+before_install:
+  - curl --location http://git.io/1OcIZA | bash -s
 node_js:
   - 0.8
-  - "0.10"
+  - 0.10
+  - 0.11
 branches:
   only:
     - master


### PR DESCRIPTION
Fixes the 0.8 build on travis by handling the npm installing properly. Also test on 0.11 because why not?