### PR TITLE
bl.append(number) appends a buffer with uninitialized memory

### DIFF
--- a/bl.js
+++ b/bl.js
@@ -52,6 +52,11 @@ BufferList.prototype.append = function (buf) {
   var isBuffer = Buffer.isBuffer(buf) ||
                  buf instanceof BufferList
 
+  // coerce number arguments to strings, since Buffer(number) does
+  // uninitialized memory allocation
+  if (typeof buf == 'number')
+    buf = buf.toString()
+
   this._bufs.push(isBuffer ? buf : new Buffer(buf))
   this.length += buf.length
   return this

--- a/test/basic-test.js
+++ b/test/basic-test.js
@@ -336,6 +336,22 @@ tape('test String appendage', function (t) {
   t.end()
 })
 
+tape('test Number appendage', function (t) {
+  var bl = new BufferList()
+    , b  = new Buffer('1234567890')
+
+  bl.append(1234)
+  bl.append(567)
+  bl.append(89)
+  bl.append(0)
+
+  encodings.forEach(function (enc) {
+      t.equal(bl.toString(enc), b.toString(enc))
+    })
+
+  t.end()
+})
+
 tape('write nothing, should get empty buffer', function (t) {
   t.plan(3)
   BufferList(function (err, data) {


### PR DESCRIPTION
This PR changes the behavior of `bl.append(number)` so that it no longer appends a buffer with uninitialized memory of the specified size.

The issue is fixed by coercing the argument to a string. (An alternate solution would be to throw an exception in this case.)

This played a role in this issue in request: https://github.com/request/request/pull/2018

Further reading:

- https://github.com/nodejs/node/issues/4660
- https://github.com/nodejs/node-eps/pull/4