### PR TITLE
Link Internal Buffers when appending another BufferList

### DIFF
--- a/bl.js
+++ b/bl.js
@@ -57,8 +57,14 @@ BufferList.prototype.append = function (buf) {
   if (typeof buf == 'number')
     buf = buf.toString()
 
-  this._bufs.push(isBuffer ? buf : new Buffer(buf))
-  this.length += buf.length
+  if (buf instanceof BufferList) {
+    this._bufs.push.apply(this._bufs, buf._bufs)
+    this.length += buf.length
+  } else {
+    this._bufs.push(isBuffer ? buf : new Buffer(buf))
+    this.length += buf.length
+  }
+
   return this
 }
 

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     "readable-stream": "~2.0.5"
   },
   "devDependencies": {
-    "tape": "~2.12.3",
+    "faucet": "0.0.1",
     "hash_file": "~0.1.1",
-    "faucet": "~0.0.1"
+    "tape": "~4.4.0"
   }
 }


### PR DESCRIPTION
This restores support for node v5.6.0. I think we should release it as a patch upgrade, as the side effects of appending to a nested `bl()` was a bug anyway.

@rvagg @jcrugzz opinions?

Fixes #26 