### PR TITLE
add shallow slice method

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ bl.pipe(fs.createWriteStream('gibberish.txt'))
   * <a href="#append"><code>bl.<b>append(buffer)</b></code></a>
   * <a href="#get"><code>bl.<b>get(index)</b></code></a>
   * <a href="#slice"><code>bl.<b>slice([ start[, end ] ])</b></code></a>
+  * <a href="#shallowSlice"><code>bl.<b>shallowSlice([ start[, end ] ])</b></code></a>
   * <a href="#copy"><code>bl.<b>copy(dest, [ destStart, [ srcStart [, srcEnd ] ] ])</b></code></a>
   * <a href="#duplicate"><code>bl.<b>duplicate()</b></code></a>
   * <a href="#consume"><code>bl.<b>consume(bytes)</b></code></a>
@@ -134,6 +135,13 @@ Get the length of the list in bytes. This is the sum of the lengths of all of th
 `slice()` returns a new `Buffer` object containing the bytes within the range specified. Both `start` and `end` are optional and will default to the beginning and end of the list respectively.
 
 If the requested range spans a single internal buffer then a slice of that buffer will be returned which shares the original memory range of that Buffer. If the range spans multiple buffers then copy operations will likely occur to give you a uniform Buffer.
+
+--------------------------------------------------------
+<a name="shallowSlice"></a>
+### bl.shallowSlice([ start, [ end ] ])
+`shallowSlice()` returns a new `BufferList` object containing the bytes within the range specified. Both `start` and `end` are optional and will default to the beginning and end of the list respectively.
+
+No copies will be performed. All buffers in the result share memory with the original list.
 
 --------------------------------------------------------
 <a name="copy"></a>

--- a/bl.js
+++ b/bl.js
@@ -40,7 +40,7 @@ BufferList.prototype._offset = function _offset (offset) {
   var tot = 0, i = 0, _t
   for (; i < this._bufs.length; i++) {
     _t = tot + this._bufs[i].length
-    if (offset < _t)
+    if (offset < _t || i == this._bufs.length - 1)
       return [ i, offset - tot ]
     tot = _t
   }
@@ -172,6 +172,31 @@ BufferList.prototype.copy = function copy (dst, dstStart, srcStart, srcEnd) {
   }
 
   return dst
+}
+
+BufferList.prototype.shallowSlice = function shallowSlice (start, end) {
+  start = start || 0
+  end = end || this.length
+
+  if(start < 0)
+    start += this.length
+  if(end < 0)
+    end += this.length
+
+  var startOffset = this._offset(start)
+  var endOffset = this._offset(end)
+
+  var buffers = this._bufs.slice(startOffset[0], endOffset[0]+1)
+
+  if(startOffset[1] != 0)
+    buffers[0] = buffers[0].slice(startOffset[1])
+
+  if(endOffset[1] == 0)
+    buffers.pop()
+  else
+    buffers[buffers.length-1] = buffers[buffers.length-1].slice(0, endOffset[1])
+
+  return new BufferList(buffers)
 }
 
 BufferList.prototype.toString = function toString (encoding, start, end) {

--- a/bl.js
+++ b/bl.js
@@ -178,15 +178,14 @@ BufferList.prototype.shallowSlice = function shallowSlice (start, end) {
   start = start || 0
   end = end || this.length
 
-  if(start < 0)
+  if (start < 0)
     start += this.length
-  if(end < 0)
+  if (end < 0)
     end += this.length
 
   var startOffset = this._offset(start)
-  var endOffset = this._offset(end)
-
-  var buffers = this._bufs.slice(startOffset[0], endOffset[0]+1)
+    , endOffset = this._offset(end)
+    , buffers = this._bufs.slice(startOffset[0], endOffset[0] + 1)
 
   if(startOffset[1] != 0)
     buffers[0] = buffers[0].slice(startOffset[1])

--- a/test/test.js
+++ b/test/test.js
@@ -537,6 +537,39 @@ tape('copy an interval between two buffers', function (t) {
   t.end()
 })
 
+tape('shallow slice across buffer boundaries', function (t) {
+  var bl = new BufferList(['First', 'Second', 'Third'])
+
+  t.equal(bl.shallowSlice(3, 13).toString(), 'stSecondTh')
+  t.end()
+})
+
+tape('shallow slice within single buffer', function (t) {
+  var bl = new BufferList(['First', 'Second', 'Third'])
+
+  t.equal(bl.shallowSlice(5, 10).toString(), 'Secon')
+  t.end()
+})
+
+tape('shallow slice single buffer', function (t) {
+  t.plan(3)
+  var bl = new BufferList(['First', 'Second', 'Third'])
+
+  t.equal(bl.shallowSlice(0, 5).toString(), 'First')
+  t.equal(bl.shallowSlice(5, 11).toString(), 'Second')
+  t.equal(bl.shallowSlice(11, 16).toString(), 'Third')
+})
+
+tape('shallow slice with negative or omitted indices', function (t) {
+  t.plan(4)
+  var bl = new BufferList(['First', 'Second', 'Third'])
+
+  t.equal(bl.shallowSlice().toString(), 'FirstSecondThird')
+  t.equal(bl.shallowSlice(5).toString(), 'SecondThird')
+  t.equal(bl.shallowSlice(5, -3).toString(), 'SecondTh')
+  t.equal(bl.shallowSlice(-8).toString(), 'ondThird')
+})
+
 tape('duplicate', function (t) {
   t.plan(2)
 

--- a/test/test.js
+++ b/test/test.js
@@ -570,6 +570,17 @@ tape('shallow slice with negative or omitted indices', function (t) {
   t.equal(bl.shallowSlice(-8).toString(), 'ondThird')
 })
 
+tape('shallow slice does not make a copy', function (t) {
+  t.plan(1)
+  var buffers = [new Buffer('First'), new Buffer('Second'), new Buffer('Third')]
+  var bl = (new BufferList(buffers)).shallowSlice(5, -3)
+
+  buffers[1].fill('h')
+  buffers[2].fill('h')
+
+  t.equal(bl.toString(), 'hhhhhhhh')
+})
+
 tape('duplicate', function (t) {
   t.plan(2)
 


### PR DESCRIPTION
This PR adds the method shallowSlice which is just like slice but returns a BufferList instead of Buffer. It never copies anything but only slices buffers where necessary.

It also fixes a minor issue in _offset that resulted in undefined being returned when indexing past the end of the BufferList.
