### PR TITLE
Fix zero-end in shallow slice

### DIFF
--- a/bl.js
+++ b/bl.js
@@ -189,7 +189,7 @@ BufferList.prototype.copy = function copy (dst, dstStart, srcStart, srcEnd) {
 
 BufferList.prototype.shallowSlice = function shallowSlice (start, end) {
   start = start || 0
-  end = end || this.length
+  end = end == null ? this.length : end
 
   if (start < 0)
     start += this.length

--- a/test/test.js
+++ b/test/test.js
@@ -566,6 +566,14 @@ tape('shallow slice within single buffer', function (t) {
   t.end()
 })
 
+tape('shallow slice of zero length', function (t) {
+  var bl = new BufferList(['First', 'Second', 'Third'])
+
+  t.equal(bl.shallowSlice(0, 0).toString(), '')
+  t.equal(bl.shallowSlice(4, 4).toString(), '')
+  t.end()
+})
+
 tape('shallow slice single buffer', function (t) {
   t.plan(3)
   var bl = new BufferList(['First', 'Second', 'Third'])


### PR DESCRIPTION
For the case
```js
bl.shallowSlice(0, 0)
```
bl returns full buffer, which seems to be wrong. So here is the fix.
Is there any sense in making bl.shallowSlice(0, -0)?