### PR TITLE
`shallowSlice` fix

### DIFF
--- a/bl.js
+++ b/bl.js
@@ -200,13 +200,13 @@ BufferList.prototype.shallowSlice = function shallowSlice (start, end) {
     , endOffset = this._offset(end)
     , buffers = this._bufs.slice(startOffset[0], endOffset[0] + 1)
 
-  if (startOffset[1] != 0)
-    buffers[0] = buffers[0].slice(startOffset[1])
-
   if (endOffset[1] == 0)
     buffers.pop()
   else
     buffers[buffers.length-1] = buffers[buffers.length-1].slice(0, endOffset[1])
+
+  if (startOffset[1] != 0)
+    buffers[0] = buffers[0].slice(startOffset[1])
 
   return new BufferList(buffers)
 }

--- a/test/test.js
+++ b/test/test.js
@@ -560,9 +560,11 @@ tape('shallow slice across buffer boundaries', function (t) {
 })
 
 tape('shallow slice within single buffer', function (t) {
+  t.plan(2)
   var bl = new BufferList(['First', 'Second', 'Third'])
 
   t.equal(bl.shallowSlice(5, 10).toString(), 'Secon')
+  t.equal(bl.shallowSlice(7, 10).toString(), 'con')
   t.end()
 })
 


### PR DESCRIPTION
When `start` offset of `shallowSlice` does not fall on the start of the buffer, and both `start` and `end` fall on the same buffer, result contains extra trailing bytes. This happens because buffer start is adjusted first, thus invalidating computed internal end offsets, causing buffer end adjustment to produce incorrect results. Proposed fix simply adjusts first end, then start, as end adjustment has no effect on computed start offsets.