### PR TITLE
improve perfomance for BufferList#get.

### DIFF
--- a/bl.js
+++ b/bl.js
@@ -2,6 +2,7 @@ var DuplexStream = require('readable-stream/duplex')
   , util         = require('util')
   , Buffer       = require('safe-buffer').Buffer
 
+var tempBuffer = Buffer.alloc(1)
 
 function BufferList (callback) {
   if (!(this instanceof BufferList))
@@ -109,7 +110,8 @@ BufferList.prototype.end = function end (chunk) {
 
 
 BufferList.prototype.get = function get (index) {
-  return this.slice(index, index + 1)[0]
+  this.copy(tempBuffer, 0, index, index + 1)
+  return tempBuffer[0]
 }
 
 


### PR DESCRIPTION
There is a slight performance improvement for bufferlist#get.

with patch:
```
+   15,59%  node     perf-25857.map       [.] LazyCompile:*copy /home/dtsvet/develop/projects/bl/bl.js:127
+   11,52%  node     node                 [.] _ZN4node6Buffer12_GLOBAL__N_14CopyERKN2v820FunctionCallbackInfoINS2_5ValueEEE
+    7,45%  node     node                 [.] _ZN2v811ArrayBuffer11GetContentsEv
+    7,30%  node     node                 [.] _ZNK2v88internal3Map11FindRootMapEv
+    5,87%  node     perf-25857.map       [.] Stub:CallApiCallbackStub
+    5,42%  node     node                 [.] _ZN2v88internal12JSTypedArray9GetBufferEv
+    4,04%  node     node                 [.] _ZNK2v85Value17IsArrayBufferViewEv
```

without patch:
```
+   19,41%  node     perf-28278.map       [.] LazyCompile:*copy /home/dtsvet/develop/projects/bl/bl.js:128
+   11,57%  node     perf-28278.map       [.] Builtin:TypedArrayConstructByArrayBuffer
+    7,15%  node     perf-28278.map       [.] Builtin:TypedArrayInitializeWithBuffer
+    6,58%  node     perf-28278.map       [.] Builtin:JSConstructStubGenericUnrestrictedReturn
+    6,08%  node     perf-28278.map       [.] Builtin:FastNewObject
```

perf test source [here](https://gist.github.com/reklatsmasters/df589ab3d795e4ef3f0d2e3ebb9240ce).