### PR TITLE
feat: add support for Uint8Array and remove instanceof usage

### DIFF
--- a/bl.js
+++ b/bl.js
@@ -60,16 +60,21 @@ BufferList.prototype._reverseOffset = function (blOffset) {
 BufferList.prototype.append = function append (buf) {
   var i = 0
 
-  if (Buffer.isBuffer(buf)) {
-    this._appendBuffer(buf)
+  if (buf == null) {
+    return this
+  }
+
+  if (buf.buffer) {
+    // append a view of the underlying ArrayBuffer
+    this._appendBuffer(Buffer.from(buf.buffer, buf.byteOffset, buf.byteLength))
   } else if (Array.isArray(buf)) {
     for (; i < buf.length; i++)
       this.append(buf[i])
-  } else if (buf instanceof BufferList) {
+  } else if (Array.isArray(buf._bufs)) {
     // unwrap argument into individual BufferLists
     for (; i < buf._bufs.length; i++)
       this.append(buf._bufs[i])
-  } else if (buf != null) {
+  } else {
     // coerce number arguments to strings, since Buffer(number) does
     // uninitialized memory allocation
     if (typeof buf == 'number')
@@ -276,8 +281,10 @@ BufferList.prototype.indexOf = function (search, offset, encoding) {
       search = Buffer.from([search])
   } else if (typeof search === 'string') {
     search = Buffer.from(search, encoding)
-  } else if (search instanceof BufferList) {
+  } else if (Array.isArray(search._bufs)) {
     search = search.slice()
+  } else if (Array.isArray(search.buffer)) {
+    search = Buffer.from(search.buffer, search.byteOffset, search.byteLength)
   } else if (!Buffer.isBuffer(search)) {
     search = Buffer.from(search)
   }

--- a/test/indexOf.js
+++ b/test/indexOf.js
@@ -40,6 +40,19 @@ tape('indexOf takes a buffer list search', t => {
   t.end()
 })
 
+tape('indexOf takes a buffer list like search', t => {
+  const bl = new BufferList(['abcdefg', 'abcdefg'])
+  const search = Buffer.from('fgabc')
+  const blLike = {
+    _bufs: [search],
+    slice: function() {
+      return search.slice()
+    }
+  }
+  t.equal(bl.indexOf(blLike), 5)
+  t.end()
+})
+
 tape('indexOf a zero byte needle', t => {
   const b = new BufferList('abcdef')
   const buf_empty = Buffer.from('')

--- a/test/indexOf.js
+++ b/test/indexOf.js
@@ -26,6 +26,13 @@ tape('indexOf multiple byte needles across buffer boundaries', t => {
   t.end()
 })
 
+tape('indexOf takes a Uint8Array search', t => {
+  const bl = new BufferList(['abcdefg', 'abcdefg'])
+  const search = new Uint8Array([102, 103, 97, 98, 99]) // fgabc
+  t.equal(bl.indexOf(search), 5)
+  t.end()
+})
+
 tape('indexOf takes a buffer list search', t => {
   const bl = new BufferList(['abcdefg', 'abcdefg'])
   const search = new BufferList('fgabc')

--- a/test/test.js
+++ b/test/test.js
@@ -176,6 +176,17 @@ tape('append accepts arrays of BufferLists', function (t) {
   t.end()
 })
 
+tape('append accepts arrays of BufferList like objects', function (t) {
+  var bl = new BufferList()
+  bl.append({ _bufs: [ Buffer.from('abc') ] })
+  bl.append([{ _bufs: [ Buffer.from('def') ] }])
+  bl.append({ _bufs: [ Buffer.from('ghi'), new BufferList('jkl') ]})
+  bl.append([ Buffer.from('mnop'), { _bufs: [ Buffer.from('qrstu'), Buffer.from('vwxyz') ]} ])
+  t.equal(bl.length, 26)
+  t.equal(bl.slice().toString('ascii'), 'abcdefghijklmnopqrstuvwxyz')
+  t.end()
+})
+
 tape('append chainable', function (t) {
   var bl = new BufferList()
   t.ok(bl.append(Buffer.from('abcd')) === bl)

--- a/test/test.js
+++ b/test/test.js
@@ -153,6 +153,18 @@ tape('append accepts arrays of Buffers', function (t) {
   t.end()
 })
 
+tape('append accepts arrays of Uint8Arrays', function (t) {
+  var bl = new BufferList()
+
+  bl.append(new Uint8Array([97, 98, 99]))
+  bl.append([ Uint8Array.from([100, 101, 102]) ])
+  bl.append([ new Uint8Array([103, 104, 105]), new Uint8Array([106, 107, 108]) ])
+  bl.append([ new Uint8Array([109, 110, 111, 112]), new Uint8Array([113, 114, 115, 116, 117]), new Uint8Array([118, 119, 120, 121, 122]) ])
+  t.equal(bl.length, 26)
+  t.equal(bl.slice().toString('ascii'), 'abcdefghijklmnopqrstuvwxyz')
+  t.end()
+})
+
 tape('append accepts arrays of BufferLists', function (t) {
   var bl = new BufferList()
   bl.append(Buffer.from('abc'))


### PR DESCRIPTION
This adds support for `Uint8Array` by doing duck type checking of `.buffer`, which also applies to `Buffer`. If it exists, the view of the underlying ArrayBuffer is appended to the BufferList so that no copying is done.

This also removes checking of `instanceof BufferList` to avoid issues with multiple versions of the module. Instead, it just checks that `._bufs` is an array before proceeding with concatenation. 

In `indexOf` I am also just checking `._bufs`, but it could potentially check `slice` before performing the action. String and Array types are already checked, so it should be a smaller chance of slicing a non BufferList.


Fixes #71