### PR TITLE
Merge for #72 and #73 (instanceof, bl-without-streams)

### DIFF
--- a/BufferList.js
+++ b/BufferList.js
@@ -1,0 +1,336 @@
+'use strict'
+
+function BufferList (buf) {
+  if (!BufferList.isBufferList(this))
+    return new BufferList(buf)
+
+  this._bufs = []
+  this.length = 0
+  if (buf) this.append(buf)
+}
+
+BufferList.prototype._new = function _new (buf) {
+  return new BufferList(buf)
+}
+
+BufferList.prototype._offset = function _offset (offset) {
+  var tot = 0, i = 0, _t
+  if (offset === 0) return [ 0, 0 ]
+  for (; i < this._bufs.length; i++) {
+    _t = tot + this._bufs[i].length
+    if (offset < _t || i == this._bufs.length - 1) {
+      return [ i, offset - tot ]
+    }
+    tot = _t
+  }
+}
+
+BufferList.prototype._reverseOffset = function (blOffset) {
+  var bufferId = blOffset[0]
+  var offset = blOffset[1]
+  for (var i = 0; i < bufferId; i++) {
+    offset += this._bufs[i].length
+  }
+  return offset
+}
+
+BufferList.prototype.get = function get (index) {
+  if (index > this.length || index < 0) {
+    return undefined
+  }
+  var offset = this._offset(index)
+  return this._bufs[offset[0]][offset[1]]
+}
+
+BufferList.prototype.slice = function slice (start, end) {
+  if (typeof start == 'number' && start < 0)
+    start += this.length
+  if (typeof end == 'number' && end < 0)
+    end += this.length
+  return this.copy(null, 0, start, end)
+}
+
+
+BufferList.prototype.copy = function copy (dst, dstStart, srcStart, srcEnd) {
+  if (typeof srcStart != 'number' || srcStart < 0)
+    srcStart = 0
+  if (typeof srcEnd != 'number' || srcEnd > this.length)
+    srcEnd = this.length
+  if (srcStart >= this.length)
+    return dst || Buffer.alloc(0)
+  if (srcEnd <= 0)
+    return dst || Buffer.alloc(0)
+
+  var copy   = !!dst
+    , off    = this._offset(srcStart)
+    , len    = srcEnd - srcStart
+    , bytes  = len
+    , bufoff = (copy && dstStart) || 0
+    , start  = off[1]
+    , l
+    , i
+
+  // copy/slice everything
+  if (srcStart === 0 && srcEnd == this.length) {
+    if (!copy) { // slice, but full concat if multiple buffers
+      return this._bufs.length === 1
+        ? this._bufs[0]
+        : Buffer.concat(this._bufs, this.length)
+    }
+
+    // copy, need to copy individual buffers
+    for (i = 0; i < this._bufs.length; i++) {
+      this._bufs[i].copy(dst, bufoff)
+      bufoff += this._bufs[i].length
+    }
+
+    return dst
+  }
+
+  // easy, cheap case where it's a subset of one of the buffers
+  if (bytes <= this._bufs[off[0]].length - start) {
+    return copy
+      ? this._bufs[off[0]].copy(dst, dstStart, start, start + bytes)
+      : this._bufs[off[0]].slice(start, start + bytes)
+  }
+
+  if (!copy) // a slice, we need something to copy in to
+    dst = Buffer.allocUnsafe(len)
+
+  for (i = off[0]; i < this._bufs.length; i++) {
+    l = this._bufs[i].length - start
+
+    if (bytes > l) {
+      this._bufs[i].copy(dst, bufoff, start)
+    } else {
+      this._bufs[i].copy(dst, bufoff, start, start + bytes)
+      break
+    }
+
+    bufoff += l
+    bytes -= l
+
+    if (start)
+      start = 0
+  }
+
+  return dst
+}
+
+BufferList.prototype.shallowSlice = function shallowSlice (start, end) {
+  start = start || 0
+  end = typeof end !== 'number' ? this.length : end
+
+  if (start < 0)
+    start += this.length
+  if (end < 0)
+    end += this.length
+
+  if (start === end) {
+    return this._new()
+  }
+  var startOffset = this._offset(start)
+    , endOffset = this._offset(end)
+    , buffers = this._bufs.slice(startOffset[0], endOffset[0] + 1)
+
+  if (endOffset[1] == 0)
+    buffers.pop()
+  else
+    buffers[buffers.length-1] = buffers[buffers.length-1].slice(0, endOffset[1])
+
+  if (startOffset[1] != 0)
+    buffers[0] = buffers[0].slice(startOffset[1])
+
+  return this._new(buffers)
+}
+
+BufferList.prototype.toString = function toString (encoding, start, end) {
+  return this.slice(start, end).toString(encoding)
+}
+
+BufferList.prototype.consume = function consume (bytes) {
+  while (this._bufs.length) {
+    if (bytes >= this._bufs[0].length) {
+      bytes -= this._bufs[0].length
+      this.length -= this._bufs[0].length
+      this._bufs.shift()
+    } else {
+      this._bufs[0] = this._bufs[0].slice(bytes)
+      this.length -= bytes
+      break
+    }
+  }
+  return this
+}
+
+
+BufferList.prototype.duplicate = function duplicate () {
+  var i = 0
+    , copy = this._new()
+
+  for (; i < this._bufs.length; i++)
+    copy.append(this._bufs[i])
+
+  return copy
+}
+
+BufferList.prototype.append = function append (buf) {
+  var i = 0
+
+  if (buf == null) {
+    return this
+  }
+
+  if (buf.buffer) {
+    // append a view of the underlying ArrayBuffer
+    this._appendBuffer(Buffer.from(buf.buffer, buf.byteOffset, buf.byteLength))
+  } else if (Array.isArray(buf)) {
+    for (; i < buf.length; i++)
+      this.append(buf[i])
+  } else if (this._isBufferList(buf)) {
+    // unwrap argument into individual BufferLists
+    for (; i < buf._bufs.length; i++)
+      this.append(buf._bufs[i])
+  } else {
+    // coerce number arguments to strings, since Buffer(number) does
+    // uninitialized memory allocation
+    if (typeof buf == 'number')
+      buf = buf.toString()
+
+    this._appendBuffer(Buffer.from(buf))
+  }
+
+  return this
+}
+
+BufferList.prototype._appendBuffer = function appendBuffer (buf) {
+  this._bufs.push(buf)
+  this.length += buf.length
+}
+
+BufferList.prototype.indexOf = function (search, offset, encoding) {
+  if (encoding === undefined && typeof offset === 'string') {
+    encoding = offset
+    offset = undefined
+  }
+  if (typeof search === 'function' || Array.isArray(search)) {
+    throw new TypeError('The "value" argument must be one of type string, Buffer, BufferList, or Uint8Array.')
+  } else if (typeof search === 'number') {
+    search = Buffer.from([search])
+  } else if (typeof search === 'string') {
+    search = Buffer.from(search, encoding)
+  } else if (this._isBufferList(search)) {
+    search = search.slice()
+  } else if (Array.isArray(search.buffer)) {
+    search = Buffer.from(search.buffer, search.byteOffset, search.byteLength)
+  } else if (!Buffer.isBuffer(search)) {
+    search = Buffer.from(search)
+  }
+
+  offset = Number(offset || 0)
+  if (isNaN(offset)) {
+    offset = 0
+  }
+
+  if (offset < 0) {
+    offset = this.length + offset
+  }
+
+  if (offset < 0) {
+    offset = 0
+  }
+
+  if (search.length === 0) {
+    return offset > this.length ? this.length : offset
+  }
+
+  var blOffset = this._offset(offset)
+  var blIndex = blOffset[0] // index of which internal buffer we're working on
+  var buffOffset = blOffset[1] // offset of the internal buffer we're working on
+
+  // scan over each buffer
+  for (blIndex; blIndex < this._bufs.length; blIndex++) {
+    var buff = this._bufs[blIndex]
+    while (buffOffset < buff.length) {
+      var availableWindow = buff.length - buffOffset
+      if (availableWindow >= search.length) {
+        var nativeSearchResult = buff.indexOf(search, buffOffset)
+        if (nativeSearchResult !== -1) {
+          return this._reverseOffset([blIndex, nativeSearchResult])
+        }
+        buffOffset = buff.length - search.length + 1 // end of native search window
+      } else {
+        var revOffset = this._reverseOffset([blIndex, buffOffset])
+        if (this._match(revOffset, search)) {
+          return revOffset
+        }
+        buffOffset++
+      }
+    }
+    buffOffset = 0
+  }
+  return -1
+}
+
+BufferList.prototype._match = function (offset, search) {
+  if (this.length - offset < search.length) {
+    return false
+  }
+  for (var searchOffset = 0; searchOffset < search.length; searchOffset++) {
+    if (this.get(offset + searchOffset) !== search[searchOffset]) {
+      return false
+    }
+  }
+  return true
+}
+
+;(function () {
+  var methods = {
+      'readDoubleBE' : 8
+    , 'readDoubleLE' : 8
+    , 'readFloatBE'  : 4
+    , 'readFloatLE'  : 4
+    , 'readInt32BE'  : 4
+    , 'readInt32LE'  : 4
+    , 'readUInt32BE' : 4
+    , 'readUInt32LE' : 4
+    , 'readInt16BE'  : 2
+    , 'readInt16LE'  : 2
+    , 'readUInt16BE' : 2
+    , 'readUInt16LE' : 2
+    , 'readInt8'     : 1
+    , 'readUInt8'    : 1
+    , 'readIntBE'    : null
+    , 'readIntLE'    : null
+    , 'readUIntBE'   : null
+    , 'readUIntLE'   : null
+  }
+
+  for (var m in methods) {
+    (function (m) {
+      if (methods[m] === null) {
+        BufferList.prototype[m] = function (offset, byteLength) {
+          return this.slice(offset, offset + byteLength)[m](0, byteLength)
+        }
+      } else {
+        BufferList.prototype[m] = function (offset) {
+          return this.slice(offset, offset + methods[m])[m](0)
+        }
+      }
+    }(m))
+  }
+}())
+
+// Used internally by the class and also as an indicator of this object being
+// a `BufferList`. It's not possible to use `instanceof BufferList` in a browser
+// environment because there could be multiple different copies of the
+// BufferList class and some `BufferList`s might be `BufferList`s.
+BufferList.prototype._isBufferList = function _isBufferList (b) {
+  return b instanceof BufferList || BufferList.isBufferList(b)
+}
+
+BufferList.isBufferList = function isBufferList (b) {
+  return b != null && Boolean(b._isBufferList) && Array.isArray(b._bufs)
+}
+
+module.exports = BufferList

--- a/BufferList.js
+++ b/BufferList.js
@@ -1,8 +1,16 @@
 'use strict'
 
+var symbol = Symbol.for('BufferList')
+
 function BufferList (buf) {
-  if (!BufferList.isBufferList(this))
+  if (!(this instanceof BufferList))
     return new BufferList(buf)
+
+  BufferList._init.call(this, buf)
+}
+
+BufferList._init = function _init (buf) {
+  Object.defineProperty(this, symbol, { value: true })
 
   this._bufs = []
   this.length = 0
@@ -330,7 +338,7 @@ BufferList.prototype._isBufferList = function _isBufferList (b) {
 }
 
 BufferList.isBufferList = function isBufferList (b) {
-  return b != null && Boolean(b._isBufferList) && Array.isArray(b._bufs)
+  return b != null && b[symbol]
 }
 
 module.exports = BufferList

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@
 The original buffers are kept intact and copies are only done as necessary. Any reads that require the use of a single original buffer will return a slice of that buffer only (which references the same memory as the original buffer). Reads that span buffers perform concatenation as required and return the results transparently.
 
 ```js
-const BufferList = require('bl')
+const { BufferList } = require('bl')
 
-var bl = new BufferList()
+const bl = new BufferList()
 bl.append(Buffer.from('abcd'))
 bl.append(Buffer.from('efg'))
 bl.append('hi')                     // bl will also accept & convert Strings
@@ -45,11 +45,11 @@ console.log(bl.readUInt16LE(10)) // 0x0403
 Give it a callback in the constructor and use it just like **[concat-stream](https://github.com/maxogden/node-concat-stream)**:
 
 ```js
-const bl = require('bl')
-    , fs = require('fs')
+const { BufferListStream } = require('bl')
+const fs = require('fs')
 
 fs.createReadStream('README.md')
-  .pipe(bl(function (err, data) { // note 'new' isn't strictly required
+  .pipe(BufferListStream((err, data) => { // note 'new' isn't strictly required
     // `data` is a complete Buffer object containing the full data
     console.log(data.toString())
   }))
@@ -58,12 +58,14 @@ fs.createReadStream('README.md')
 Note that when you use the *callback* method like this, the resulting `data` parameter is a concatenation of all `Buffer` objects in the list. If you want to avoid the overhead of this concatenation (in cases of extreme performance consciousness), then avoid the *callback* method and just listen to `'end'` instead, like a standard Stream.
 
 Or to fetch a URL using [hyperquest](https://github.com/substack/hyperquest) (should work with [request](http://github.com/mikeal/request) and even plain Node http too!):
+
 ```js
 const hyperquest = require('hyperquest')
-    , bl         = require('bl')
-    , url        = 'https://raw.github.com/rvagg/bl/master/README.md'
+const { BufferListStream } = require('bl')
 
-hyperquest(url).pipe(bl(function (err, data) {
+const url = 'https://raw.github.com/rvagg/bl/master/README.md'
+
+hyperquest(url).pipe(BufferListStream((err, data) => {
   console.log(data.toString())
 }))
 ```
@@ -71,8 +73,8 @@ hyperquest(url).pipe(bl(function (err, data) {
 Or, use it as a readable stream to recompose a list of Buffers to an output source:
 
 ```js
-const BufferList = require('bl')
-    , fs         = require('fs')
+const { BufferList } = require('bl')
+const fs = require('fs')
 
 var bl = new BufferList()
 bl.append(Buffer.from('abcd'))
@@ -85,7 +87,8 @@ bl.pipe(fs.createWriteStream('gibberish.txt'))
 
 ## API
 
-  * <a href="#ctor"><code><b>new BufferList([ callback ])</b></code></a>
+  * <a href="#ctor"><code><b>new BufferList([ buf ])</b></code></a>
+  * <a href="#isBufferList"><code><b>BufferList.isBufferList(obj)</b></code></a>
   * <a href="#length"><code>bl.<b>length</b></code></a>
   * <a href="#append"><code>bl.<b>append(buffer)</b></code></a>
   * <a href="#get"><code>bl.<b>get(index)</b></code></a>
@@ -97,26 +100,31 @@ bl.pipe(fs.createWriteStream('gibberish.txt'))
   * <a href="#consume"><code>bl.<b>consume(bytes)</b></code></a>
   * <a href="#toString"><code>bl.<b>toString([encoding, [ start, [ end ]]])</b></code></a>
   * <a href="#readXX"><code>bl.<b>readDoubleBE()</b></code>, <code>bl.<b>readDoubleLE()</b></code>, <code>bl.<b>readFloatBE()</b></code>, <code>bl.<b>readFloatLE()</b></code>, <code>bl.<b>readInt32BE()</b></code>, <code>bl.<b>readInt32LE()</b></code>, <code>bl.<b>readUInt32BE()</b></code>, <code>bl.<b>readUInt32LE()</b></code>, <code>bl.<b>readInt16BE()</b></code>, <code>bl.<b>readInt16LE()</b></code>, <code>bl.<b>readUInt16BE()</b></code>, <code>bl.<b>readUInt16LE()</b></code>, <code>bl.<b>readInt8()</b></code>, <code>bl.<b>readUInt8()</b></code></a>
-  * <a href="#streams">Streams</a>
+  * <a href="#ctorStream"><code><b>new BufferListStream([ callback ])</b></code></a>
 
 --------------------------------------------------------
 <a name="ctor"></a>
-### new BufferList([ callback | Buffer | Buffer array | BufferList | BufferList array | String ])
-The constructor takes an optional callback, if supplied, the callback will be called with an error argument followed by a reference to the **bl** instance, when `bl.end()` is called (i.e. from a piped stream). This is a convenient method of collecting the entire contents of a stream, particularly when the stream is *chunky*, such as a network stream.
-
-Normally, no arguments are required for the constructor, but you can initialise the list by passing in a single `Buffer` object or an array of `Buffer` object.
+### new BufferList([ Buffer | Buffer array | BufferList | BufferList array | String ])
+No arguments are _required_ for the constructor, but you can initialise the list by passing in a single `Buffer` object or an array of `Buffer` objects.
 
 `new` is not strictly required, if you don't instantiate a new object, it will be done automatically for you so you can create a new instance simply with:
 
 ```js
-var bl = require('bl')
-var myinstance = bl()
+const { BufferList } = require('bl')
+const bl = BufferList()
 
 // equivalent to:
 
-var BufferList = require('bl')
-var myinstance = new BufferList()
+const { BufferList } = require('bl')
+const bl = new BufferList()
 ```
+
+--------------------------------------------------------
+<a name="isBufferList"></a>
+### BufferList.isBufferList(obj)
+Determines if the passed object is a `BufferList`. It will return `true` if the passed object is an instance of `BufferList` **or** `BufferListStream` and `false` otherwise.
+
+N.B. this won't return `true` for `BufferList` or `BufferListStream` instances created by versions of this library before this static method was added.
 
 --------------------------------------------------------
 <a name="length"></a>
@@ -194,9 +202,33 @@ All of the standard byte-reading methods of the `Buffer` interface are implement
 See the <b><code>[Buffer](http://nodejs.org/docs/latest/api/buffer.html)</code></b> documentation for how these work.
 
 --------------------------------------------------------
-<a name="streams"></a>
-### Streams
-**bl** is a Node **[Duplex Stream](http://nodejs.org/docs/latest/api/stream.html#stream_class_stream_duplex)**, so it can be read from and written to like a standard Node stream. You can also `pipe()` to and from a **bl** instance.
+<a name="ctorStream"></a>
+### new BufferListStream([ callback | Buffer | Buffer array | BufferList | BufferList array | String ])
+**BufferListStream** is a Node **[Duplex Stream](http://nodejs.org/docs/latest/api/stream.html#stream_class_stream_duplex)**, so it can be read from and written to like a standard Node stream. You can also `pipe()` to and from a **BufferListStream** instance.
+
+The constructor takes an optional callback, if supplied, the callback will be called with an error argument followed by a reference to the **bl** instance, when `bl.end()` is called (i.e. from a piped stream). This is a convenient method of collecting the entire contents of a stream, particularly when the stream is *chunky*, such as a network stream.
+
+Normally, no arguments are required for the constructor, but you can initialise the list by passing in a single `Buffer` object or an array of `Buffer` object.
+
+`new` is not strictly required, if you don't instantiate a new object, it will be done automatically for you so you can create a new instance simply with:
+
+```js
+const { BufferListStream } = require('bl')
+const bl = BufferListStream()
+
+// equivalent to:
+
+const { BufferListStream } = require('bl')
+const bl = new BufferListStream()
+```
+
+N.B. For backwards compatibility reasons, `BufferListStream` is the **default** export when you `require('bl')`:
+
+```js
+const { BufferListStream } = require('bl')
+// equivalent to:
+const BufferListStream = require('bl')
+```
 
 --------------------------------------------------------
 

--- a/bl.js
+++ b/bl.js
@@ -1,13 +1,11 @@
 'use strict'
 var DuplexStream = require('readable-stream').Duplex
   , util         = require('util')
+  , BufferList   = require('./BufferList')
 
-function BufferList (callback) {
-  if (!(this instanceof BufferList))
-    return new BufferList(callback)
-
-  this._bufs  = []
-  this.length = 0
+function BufferListStream (callback) {
+  if (!BufferListStream.isBufferList(this))
+    return new BufferListStream(callback)
 
   if (typeof callback == 'function') {
     this._callback = callback
@@ -25,83 +23,28 @@ function BufferList (callback) {
     this.on('unpipe', function onUnpipe (src) {
       src.removeListener('error', piper)
     })
-  } else {
-    this.append(callback)
+    callback = null
   }
 
+  BufferList.call(this, callback)
   DuplexStream.call(this)
 }
 
+util.inherits(BufferListStream, DuplexStream)
+Object.assign(BufferListStream.prototype, BufferList.prototype)
 
-util.inherits(BufferList, DuplexStream)
-
-
-BufferList.prototype._offset = function _offset (offset) {
-  var tot = 0, i = 0, _t
-  if (offset === 0) return [ 0, 0 ]
-  for (; i < this._bufs.length; i++) {
-    _t = tot + this._bufs[i].length
-    if (offset < _t || i == this._bufs.length - 1) {
-      return [ i, offset - tot ]
-    }
-    tot = _t
-  }
+BufferListStream.prototype._new = function _new (callback) {
+  return new BufferListStream(callback)
 }
 
-BufferList.prototype._reverseOffset = function (blOffset) {
-  var bufferId = blOffset[0]
-  var offset = blOffset[1]
-  for (var i = 0; i < bufferId; i++) {
-    offset += this._bufs[i].length
-  }
-  return offset
-}
-
-BufferList.prototype.append = function append (buf) {
-  var i = 0
-
-  if (buf == null) {
-    return this
-  }
-
-  if (buf.buffer) {
-    // append a view of the underlying ArrayBuffer
-    this._appendBuffer(Buffer.from(buf.buffer, buf.byteOffset, buf.byteLength))
-  } else if (Array.isArray(buf)) {
-    for (; i < buf.length; i++)
-      this.append(buf[i])
-  } else if (Array.isArray(buf._bufs)) {
-    // unwrap argument into individual BufferLists
-    for (; i < buf._bufs.length; i++)
-      this.append(buf._bufs[i])
-  } else {
-    // coerce number arguments to strings, since Buffer(number) does
-    // uninitialized memory allocation
-    if (typeof buf == 'number')
-      buf = buf.toString()
-
-    this._appendBuffer(Buffer.from(buf))
-  }
-
-  return this
-}
-
-
-BufferList.prototype._appendBuffer = function appendBuffer (buf) {
-  this._bufs.push(buf)
-  this.length += buf.length
-}
-
-
-BufferList.prototype._write = function _write (buf, encoding, callback) {
+BufferListStream.prototype._write = function _write (buf, encoding, callback) {
   this._appendBuffer(buf)
 
   if (typeof callback == 'function')
     callback()
 }
 
-
-BufferList.prototype._read = function _read (size) {
+BufferListStream.prototype._read = function _read (size) {
   if (!this.length)
     return this.push(null)
 
@@ -110,8 +53,7 @@ BufferList.prototype._read = function _read (size) {
   this.consume(size)
 }
 
-
-BufferList.prototype.end = function end (chunk) {
+BufferListStream.prototype.end = function end (chunk) {
   DuplexStream.prototype.end.call(this, chunk)
 
   if (this._callback) {
@@ -120,270 +62,18 @@ BufferList.prototype.end = function end (chunk) {
   }
 }
 
-
-BufferList.prototype.get = function get (index) {
-  if (index > this.length || index < 0) {
-    return undefined
-  }
-  var offset = this._offset(index)
-  return this._bufs[offset[0]][offset[1]]
-}
-
-
-BufferList.prototype.slice = function slice (start, end) {
-  if (typeof start == 'number' && start < 0)
-    start += this.length
-  if (typeof end == 'number' && end < 0)
-    end += this.length
-  return this.copy(null, 0, start, end)
-}
-
-
-BufferList.prototype.copy = function copy (dst, dstStart, srcStart, srcEnd) {
-  if (typeof srcStart != 'number' || srcStart < 0)
-    srcStart = 0
-  if (typeof srcEnd != 'number' || srcEnd > this.length)
-    srcEnd = this.length
-  if (srcStart >= this.length)
-    return dst || Buffer.alloc(0)
-  if (srcEnd <= 0)
-    return dst || Buffer.alloc(0)
-
-  var copy   = !!dst
-    , off    = this._offset(srcStart)
-    , len    = srcEnd - srcStart
-    , bytes  = len
-    , bufoff = (copy && dstStart) || 0
-    , start  = off[1]
-    , l
-    , i
-
-  // copy/slice everything
-  if (srcStart === 0 && srcEnd == this.length) {
-    if (!copy) { // slice, but full concat if multiple buffers
-      return this._bufs.length === 1
-        ? this._bufs[0]
-        : Buffer.concat(this._bufs, this.length)
-    }
-
-    // copy, need to copy individual buffers
-    for (i = 0; i < this._bufs.length; i++) {
-      this._bufs[i].copy(dst, bufoff)
-      bufoff += this._bufs[i].length
-    }
-
-    return dst
-  }
-
-  // easy, cheap case where it's a subset of one of the buffers
-  if (bytes <= this._bufs[off[0]].length - start) {
-    return copy
-      ? this._bufs[off[0]].copy(dst, dstStart, start, start + bytes)
-      : this._bufs[off[0]].slice(start, start + bytes)
-  }
-
-  if (!copy) // a slice, we need something to copy in to
-    dst = Buffer.allocUnsafe(len)
-
-  for (i = off[0]; i < this._bufs.length; i++) {
-    l = this._bufs[i].length - start
-
-    if (bytes > l) {
-      this._bufs[i].copy(dst, bufoff, start)
-    } else {
-      this._bufs[i].copy(dst, bufoff, start, start + bytes)
-      break
-    }
-
-    bufoff += l
-    bytes -= l
-
-    if (start)
-      start = 0
-  }
-
-  return dst
-}
-
-BufferList.prototype.shallowSlice = function shallowSlice (start, end) {
-  start = start || 0
-  end = typeof end !== 'number' ? this.length : end
-
-  if (start < 0)
-    start += this.length
-  if (end < 0)
-    end += this.length
-
-  if (start === end) {
-    return new BufferList()
-  }
-  var startOffset = this._offset(start)
-    , endOffset = this._offset(end)
-    , buffers = this._bufs.slice(startOffset[0], endOffset[0] + 1)
-
-  if (endOffset[1] == 0)
-    buffers.pop()
-  else
-    buffers[buffers.length-1] = buffers[buffers.length-1].slice(0, endOffset[1])
-
-  if (startOffset[1] != 0)
-    buffers[0] = buffers[0].slice(startOffset[1])
-
-  return new BufferList(buffers)
-}
-
-BufferList.prototype.toString = function toString (encoding, start, end) {
-  return this.slice(start, end).toString(encoding)
-}
-
-BufferList.prototype.consume = function consume (bytes) {
-  while (this._bufs.length) {
-    if (bytes >= this._bufs[0].length) {
-      bytes -= this._bufs[0].length
-      this.length -= this._bufs[0].length
-      this._bufs.shift()
-    } else {
-      this._bufs[0] = this._bufs[0].slice(bytes)
-      this.length -= bytes
-      break
-    }
-  }
-  return this
-}
-
-
-BufferList.prototype.duplicate = function duplicate () {
-  var i = 0
-    , copy = new BufferList()
-
-  for (; i < this._bufs.length; i++)
-    copy.append(this._bufs[i])
-
-  return copy
-}
-
-
-BufferList.prototype._destroy = function _destroy (err, cb) {
+BufferListStream.prototype._destroy = function _destroy (err, cb) {
   this._bufs.length = 0
   this.length = 0
   cb(err)
 }
 
-
-BufferList.prototype.indexOf = function (search, offset, encoding) {
-  if (encoding === undefined && typeof offset === 'string') {
-    encoding = offset
-    offset = undefined
-  }
-  if (typeof search === 'function' || Array.isArray(search)) {
-    throw new TypeError('The "value" argument must be one of type string, Buffer, BufferList, or Uint8Array.')
-  } else if (typeof search === 'number') {
-      search = Buffer.from([search])
-  } else if (typeof search === 'string') {
-    search = Buffer.from(search, encoding)
-  } else if (Array.isArray(search._bufs)) {
-    search = search.slice()
-  } else if (Array.isArray(search.buffer)) {
-    search = Buffer.from(search.buffer, search.byteOffset, search.byteLength)
-  } else if (!Buffer.isBuffer(search)) {
-    search = Buffer.from(search)
-  }
-
-  offset = Number(offset || 0)
-  if (isNaN(offset)) {
-    offset = 0
-  }
-
-  if (offset < 0) {
-    offset = this.length + offset
-  }
-
-  if (offset < 0) {
-    offset = 0
-  }
-
-  if (search.length === 0) {
-    return offset > this.length ? this.length : offset
-  }
-
-  var blOffset = this._offset(offset)
-  var blIndex = blOffset[0] // index of which internal buffer we're working on
-  var buffOffset = blOffset[1] // offset of the internal buffer we're working on
-
-  // scan over each buffer
-  for (blIndex; blIndex < this._bufs.length; blIndex++) {
-    var buff = this._bufs[blIndex]
-    while(buffOffset < buff.length) {
-      var availableWindow = buff.length - buffOffset
-      if (availableWindow >= search.length) {
-        var nativeSearchResult = buff.indexOf(search, buffOffset)
-        if (nativeSearchResult !== -1) {
-          return this._reverseOffset([blIndex, nativeSearchResult])
-        }
-        buffOffset = buff.length - search.length + 1 // end of native search window
-      } else {
-        var revOffset = this._reverseOffset([blIndex, buffOffset])
-        if (this._match(revOffset, search)) {
-          return revOffset
-        }
-        buffOffset++
-      }
-    }
-    buffOffset = 0
-  }
-  return -1
+BufferListStream.prototype._isBufferList = function _isBufferList (b) {
+  return b instanceof BufferListStream || b instanceof BufferList || BufferListStream.isBufferList(b)
 }
 
-BufferList.prototype._match = function(offset, search) {
-  if (this.length - offset < search.length) {
-    return false
-  }
-  for (var searchOffset = 0; searchOffset < search.length ; searchOffset++) {
-    if(this.get(offset + searchOffset) !== search[searchOffset]){
-      return false
-    }
-  }
-  return true
-}
+BufferListStream.isBufferList = BufferList.isBufferList
 
-
-;(function () {
-  var methods = {
-      'readDoubleBE' : 8
-    , 'readDoubleLE' : 8
-    , 'readFloatBE'  : 4
-    , 'readFloatLE'  : 4
-    , 'readInt32BE'  : 4
-    , 'readInt32LE'  : 4
-    , 'readUInt32BE' : 4
-    , 'readUInt32LE' : 4
-    , 'readInt16BE'  : 2
-    , 'readInt16LE'  : 2
-    , 'readUInt16BE' : 2
-    , 'readUInt16LE' : 2
-    , 'readInt8'     : 1
-    , 'readUInt8'    : 1
-    , 'readIntBE'    : null
-    , 'readIntLE'    : null
-    , 'readUIntBE'   : null
-    , 'readUIntLE'   : null
-  }
-
-  for (var m in methods) {
-    (function (m) {
-      if (methods[m] === null) {
-        BufferList.prototype[m] = function (offset, byteLength) {
-          return this.slice(offset, offset + byteLength)[m](0, byteLength)
-        }
-      }
-      else {
-        BufferList.prototype[m] = function (offset) {
-          return this.slice(offset, offset + methods[m])[m](0)
-        }
-      }
-    }(m))
-  }
-}())
-
-
-module.exports = BufferList
+module.exports = BufferListStream
+module.exports.BufferListStream = BufferListStream
+module.exports.BufferList = BufferList

--- a/bl.js
+++ b/bl.js
@@ -4,7 +4,7 @@ var DuplexStream = require('readable-stream').Duplex
   , BufferList   = require('./BufferList')
 
 function BufferListStream (callback) {
-  if (!BufferListStream.isBufferList(this))
+  if (!(this instanceof BufferListStream))
     return new BufferListStream(callback)
 
   if (typeof callback == 'function') {
@@ -26,7 +26,7 @@ function BufferListStream (callback) {
     callback = null
   }
 
-  BufferList.call(this, callback)
+  BufferList._init.call(this, callback)
   DuplexStream.call(this)
 }
 

--- a/bl.js
+++ b/bl.js
@@ -60,16 +60,21 @@ BufferList.prototype._reverseOffset = function (blOffset) {
 BufferList.prototype.append = function append (buf) {
   var i = 0
 
-  if (Buffer.isBuffer(buf)) {
-    this._appendBuffer(buf)
+  if (buf == null) {
+    return this
+  }
+
+  if (buf.buffer) {
+    // append a view of the underlying ArrayBuffer
+    this._appendBuffer(Buffer.from(buf.buffer, buf.byteOffset, buf.byteLength))
   } else if (Array.isArray(buf)) {
     for (; i < buf.length; i++)
       this.append(buf[i])
-  } else if (buf instanceof BufferList) {
+  } else if (Array.isArray(buf._bufs)) {
     // unwrap argument into individual BufferLists
     for (; i < buf._bufs.length; i++)
       this.append(buf._bufs[i])
-  } else if (buf != null) {
+  } else {
     // coerce number arguments to strings, since Buffer(number) does
     // uninitialized memory allocation
     if (typeof buf == 'number')
@@ -276,8 +281,10 @@ BufferList.prototype.indexOf = function (search, offset, encoding) {
       search = Buffer.from([search])
   } else if (typeof search === 'string') {
     search = Buffer.from(search, encoding)
-  } else if (search instanceof BufferList) {
+  } else if (Array.isArray(search._bufs)) {
     search = search.slice()
+  } else if (Array.isArray(search.buffer)) {
+    search = Buffer.from(search.buffer, search.byteOffset, search.byteLength)
   } else if (!Buffer.isBuffer(search)) {
     search = Buffer.from(search)
   }

--- a/test/convert.js
+++ b/test/convert.js
@@ -8,7 +8,7 @@ tape('convert from BufferList to BufferListStream', t => {
   const data = Buffer.from(`TEST-${Date.now()}`)
   const bl = new BufferList(data)
   const bls = new BufferListStream(bl)
-  t.equal(bl.slice(), bls.slice())
+  t.ok(bl.slice().equals(bls.slice()))
   t.end()
 })
 
@@ -16,6 +16,6 @@ tape('convert from BufferListStream to BufferList', t => {
   const data = Buffer.from(`TEST-${Date.now()}`)
   const bls = new BufferListStream(data)
   const bl = new BufferList(bls)
-  t.equal(bl.slice(), bls.slice())
+  t.ok(bl.slice().equals(bls.slice()))
   t.end()
 })

--- a/test/convert.js
+++ b/test/convert.js
@@ -1,0 +1,21 @@
+'use strict'
+
+const tape = require('tape')
+const { BufferList, BufferListStream } = require('../')
+const { Buffer } = require('safe-buffer')
+
+tape('convert from BufferList to BufferListStream', t => {
+  const data = Buffer.from(`TEST-${Date.now()}`)
+  const bl = new BufferList(data)
+  const bls = new BufferListStream(bl)
+  t.equal(bl.slice(), bls.slice())
+  t.end()
+})
+
+tape('convert from BufferListStream to BufferList', t => {
+  const data = Buffer.from(`TEST-${Date.now()}`)
+  const bls = new BufferListStream(data)
+  const bl = new BufferList(bls)
+  t.equal(bl.slice(), bls.slice())
+  t.end()
+})

--- a/test/indexOf.js
+++ b/test/indexOf.js
@@ -40,6 +40,19 @@ tape('indexOf takes a buffer list search', t => {
   t.end()
 })
 
+tape('indexOf takes a buffer list like search', t => {
+  const bl = new BufferList(['abcdefg', 'abcdefg'])
+  const search = Buffer.from('fgabc')
+  const blLike = {
+    _bufs: [search],
+    slice: function() {
+      return search.slice()
+    }
+  }
+  t.equal(bl.indexOf(blLike), 5)
+  t.end()
+})
+
 tape('indexOf a zero byte needle', t => {
   const b = new BufferList('abcdef')
   const buf_empty = Buffer.from('')

--- a/test/indexOf.js
+++ b/test/indexOf.js
@@ -26,6 +26,13 @@ tape('indexOf multiple byte needles across buffer boundaries', t => {
   t.end()
 })
 
+tape('indexOf takes a Uint8Array search', t => {
+  const bl = new BufferList(['abcdefg', 'abcdefg'])
+  const search = new Uint8Array([102, 103, 97, 98, 99]) // fgabc
+  t.equal(bl.indexOf(search), 5)
+  t.end()
+})
+
 tape('indexOf takes a buffer list search', t => {
   const bl = new BufferList(['abcdefg', 'abcdefg'])
   const search = new BufferList('fgabc')

--- a/test/indexOf.js
+++ b/test/indexOf.js
@@ -40,19 +40,6 @@ tape('indexOf takes a buffer list search', t => {
   t.end()
 })
 
-tape('indexOf takes a buffer list like search', t => {
-  const bl = new BufferList(['abcdefg', 'abcdefg'])
-  const search = Buffer.from('fgabc')
-  const blLike = {
-    _bufs: [search],
-    slice: function() {
-      return search.slice()
-    }
-  }
-  t.equal(bl.indexOf(blLike), 5)
-  t.end()
-})
-
 tape('indexOf a zero byte needle', t => {
   const b = new BufferList('abcdef')
   const buf_empty = Buffer.from('')

--- a/test/isBufferList.js
+++ b/test/isBufferList.js
@@ -1,0 +1,28 @@
+'use strict'
+
+const tape = require('tape')
+const { BufferList, BufferListStream } = require('../')
+const { Buffer } = require('safe-buffer')
+
+tape('isBufferList positives', t => {
+  for (const obj of [
+    new BufferList(),
+    new BufferListStream()
+  ]) t.ok(BufferList.isBufferList(obj))
+  t.end()
+})
+
+tape('isBufferList negatives', t => {
+  for (const obj of [
+    null,
+    undefined,
+    NaN,
+    true,
+    false,
+    {},
+    [],
+    Buffer.alloc(0),
+    [Buffer.alloc(0)]
+  ]) t.notOk(BufferList.isBufferList(obj))
+  t.end()
+})

--- a/test/test.js
+++ b/test/test.js
@@ -176,6 +176,17 @@ tape('append accepts arrays of BufferLists', function (t) {
   t.end()
 })
 
+tape('append accepts arrays of BufferList like objects', function (t) {
+  var bl = new BufferList()
+  bl.append({ _bufs: [ Buffer.from('abc') ] })
+  bl.append([{ _bufs: [ Buffer.from('def') ] }])
+  bl.append({ _bufs: [ Buffer.from('ghi'), new BufferList('jkl') ]})
+  bl.append([ Buffer.from('mnop'), { _bufs: [ Buffer.from('qrstu'), Buffer.from('vwxyz') ]} ])
+  t.equal(bl.length, 26)
+  t.equal(bl.slice().toString('ascii'), 'abcdefghijklmnopqrstuvwxyz')
+  t.end()
+})
+
 tape('append chainable', function (t) {
   var bl = new BufferList()
   t.ok(bl.append(Buffer.from('abcd')) === bl)

--- a/test/test.js
+++ b/test/test.js
@@ -153,6 +153,18 @@ tape('append accepts arrays of Buffers', function (t) {
   t.end()
 })
 
+tape('append accepts arrays of Uint8Arrays', function (t) {
+  var bl = new BufferList()
+
+  bl.append(new Uint8Array([97, 98, 99]))
+  bl.append([ Uint8Array.from([100, 101, 102]) ])
+  bl.append([ new Uint8Array([103, 104, 105]), new Uint8Array([106, 107, 108]) ])
+  bl.append([ new Uint8Array([109, 110, 111, 112]), new Uint8Array([113, 114, 115, 116, 117]), new Uint8Array([118, 119, 120, 121, 122]) ])
+  t.equal(bl.length, 26)
+  t.equal(bl.slice().toString('ascii'), 'abcdefghijklmnopqrstuvwxyz')
+  t.end()
+})
+
 tape('append accepts arrays of BufferLists', function (t) {
   var bl = new BufferList()
   bl.append(Buffer.from('abc'))

--- a/test/test.js
+++ b/test/test.js
@@ -13,6 +13,8 @@ var tape       = require('tape')
 
 // run the indexOf tests
 require('./indexOf')
+require('./isBufferList')
+require('./convert')
 
 tape('single bytes from single buffer', function (t) {
   var bl = new BufferList()

--- a/test/test.js
+++ b/test/test.js
@@ -11,7 +11,6 @@ var tape       = require('tape')
       ('hex utf8 utf-8 ascii binary base64'
           + (process.browser ? '' : ' ucs2 ucs-2 utf16le utf-16le')).split(' ')
 
-// run the indexOf tests
 require('./indexOf')
 require('./isBufferList')
 require('./convert')
@@ -173,17 +172,6 @@ tape('append accepts arrays of BufferLists', function (t) {
   bl.append([ new BufferList('def') ])
   bl.append(new BufferList([ Buffer.from('ghi'), new BufferList('jkl') ]))
   bl.append([ Buffer.from('mnop'), new BufferList([ Buffer.from('qrstu'), Buffer.from('vwxyz') ]) ])
-  t.equal(bl.length, 26)
-  t.equal(bl.slice().toString('ascii'), 'abcdefghijklmnopqrstuvwxyz')
-  t.end()
-})
-
-tape('append accepts arrays of BufferList like objects', function (t) {
-  var bl = new BufferList()
-  bl.append({ _bufs: [ Buffer.from('abc') ] })
-  bl.append([{ _bufs: [ Buffer.from('def') ] }])
-  bl.append({ _bufs: [ Buffer.from('ghi'), new BufferList('jkl') ]})
-  bl.append([ Buffer.from('mnop'), { _bufs: [ Buffer.from('qrstu'), Buffer.from('vwxyz') ]} ])
   t.equal(bl.length, 26)
   t.equal(bl.slice().toString('ascii'), 'abcdefghijklmnopqrstuvwxyz')
   t.end()


### PR DESCRIPTION
This is a merge of #72 and #73 with some additional pieces.

First 3 commits are a straight cherry-pick of #72, plus a fixed #73 to fit on top of it.

I had some difficulty getting #73's `isBufferList()` approach to play nicely with the tests, mainly because of the replacement of the `if (!(this instanceof Type)) return new Type()` construct at the top of the constructor(s). _But_, the only reason this construct is there is so that you can avoid `new`, so using `instanceof` shouldn't be a problem here even in the browser since you're not doing any mush-things-together operations, you're creating entirely new things. So I've restored that and I think the approach is fine even with the split `BufferListStream` and `BufferList`.

While I was playing with this I ended up bailing on the approach that both approaches to determining "isBufferList" and went with a `Symbol` set on a `BufferList` instance and checking that. Which gets us closer to `instanceof` I think. But it does make the duck-typing of #72 go away entirely, I'm not sure how you feel about that @jacobheun?

So @jacobheun and @alanshaw would you mind having a look over this?

And @mcollina if you have time for a review, even a quick one, that would be really helpful.

Further comments inline.