### PR TITLE
style: use 'standard', minor formatting & syntax changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ node_js:
   - '6'
   - '8'
   - '10'
+  - '12'
+  - master
 branches:
   only:
     - master

--- a/BufferList.js
+++ b/BufferList.js
@@ -1,10 +1,11 @@
 'use strict'
 
-var symbol = Symbol.for('BufferList')
+const symbol = Symbol.for('BufferList')
 
 function BufferList (buf) {
-  if (!(this instanceof BufferList))
+  if (!(this instanceof BufferList)) {
     return new BufferList(buf)
+  }
 
   BufferList._init.call(this, buf)
 }
@@ -14,7 +15,10 @@ BufferList._init = function _init (buf) {
 
   this._bufs = []
   this.length = 0
-  if (buf) this.append(buf)
+
+  if (buf) {
+    this.append(buf)
+  }
 }
 
 BufferList.prototype._new = function _new (buf) {
@@ -22,23 +26,29 @@ BufferList.prototype._new = function _new (buf) {
 }
 
 BufferList.prototype._offset = function _offset (offset) {
-  var tot = 0, i = 0, _t
-  if (offset === 0) return [ 0, 0 ]
-  for (; i < this._bufs.length; i++) {
-    _t = tot + this._bufs[i].length
-    if (offset < _t || i == this._bufs.length - 1) {
-      return [ i, offset - tot ]
+  if (offset === 0) {
+    return [0, 0]
+  }
+
+  let tot = 0
+
+  for (let i = 0; i < this._bufs.length; i++) {
+    const _t = tot + this._bufs[i].length
+    if (offset < _t || i === this._bufs.length - 1) {
+      return [i, offset - tot]
     }
     tot = _t
   }
 }
 
 BufferList.prototype._reverseOffset = function (blOffset) {
-  var bufferId = blOffset[0]
-  var offset = blOffset[1]
-  for (var i = 0; i < bufferId; i++) {
+  const bufferId = blOffset[0]
+  let offset = blOffset[1]
+
+  for (let i = 0; i < bufferId; i++) {
     offset += this._bufs[i].length
   }
+
   return offset
 }
 
@@ -46,48 +56,59 @@ BufferList.prototype.get = function get (index) {
   if (index > this.length || index < 0) {
     return undefined
   }
-  var offset = this._offset(index)
+
+  const offset = this._offset(index)
+
   return this._bufs[offset[0]][offset[1]]
 }
 
 BufferList.prototype.slice = function slice (start, end) {
-  if (typeof start == 'number' && start < 0)
+  if (typeof start === 'number' && start < 0) {
     start += this.length
-  if (typeof end == 'number' && end < 0)
+  }
+
+  if (typeof end === 'number' && end < 0) {
     end += this.length
+  }
+
   return this.copy(null, 0, start, end)
 }
 
-
 BufferList.prototype.copy = function copy (dst, dstStart, srcStart, srcEnd) {
-  if (typeof srcStart != 'number' || srcStart < 0)
+  if (typeof srcStart !== 'number' || srcStart < 0) {
     srcStart = 0
-  if (typeof srcEnd != 'number' || srcEnd > this.length)
-    srcEnd = this.length
-  if (srcStart >= this.length)
-    return dst || Buffer.alloc(0)
-  if (srcEnd <= 0)
-    return dst || Buffer.alloc(0)
+  }
 
-  var copy   = !!dst
-    , off    = this._offset(srcStart)
-    , len    = srcEnd - srcStart
-    , bytes  = len
-    , bufoff = (copy && dstStart) || 0
-    , start  = off[1]
-    , l
-    , i
+  if (typeof srcEnd !== 'number' || srcEnd > this.length) {
+    srcEnd = this.length
+  }
+
+  if (srcStart >= this.length) {
+    return dst || Buffer.alloc(0)
+  }
+
+  if (srcEnd <= 0) {
+    return dst || Buffer.alloc(0)
+  }
+
+  const copy = !!dst
+  const off = this._offset(srcStart)
+  const len = srcEnd - srcStart
+  let bytes = len
+  let bufoff = (copy && dstStart) || 0
+  let start = off[1]
 
   // copy/slice everything
-  if (srcStart === 0 && srcEnd == this.length) {
-    if (!copy) { // slice, but full concat if multiple buffers
+  if (srcStart === 0 && srcEnd === this.length) {
+    if (!copy) {
+      // slice, but full concat if multiple buffers
       return this._bufs.length === 1
         ? this._bufs[0]
         : Buffer.concat(this._bufs, this.length)
     }
 
     // copy, need to copy individual buffers
-    for (i = 0; i < this._bufs.length; i++) {
+    for (let i = 0; i < this._bufs.length; i++) {
       this._bufs[i].copy(dst, bufoff)
       bufoff += this._bufs[i].length
     }
@@ -102,11 +123,13 @@ BufferList.prototype.copy = function copy (dst, dstStart, srcStart, srcEnd) {
       : this._bufs[off[0]].slice(start, start + bytes)
   }
 
-  if (!copy) // a slice, we need something to copy in to
+  if (!copy) {
+    // a slice, we need something to copy in to
     dst = Buffer.allocUnsafe(len)
+  }
 
-  for (i = off[0]; i < this._bufs.length; i++) {
-    l = this._bufs[i].length - start
+  for (let i = off[0]; i < this._bufs.length; i++) {
+    const l = this._bufs[i].length - start
 
     if (bytes > l) {
       this._bufs[i].copy(dst, bufoff, start)
@@ -118,8 +141,9 @@ BufferList.prototype.copy = function copy (dst, dstStart, srcStart, srcEnd) {
     bufoff += l
     bytes -= l
 
-    if (start)
+    if (start) {
       start = 0
+    }
   }
 
   return dst
@@ -129,25 +153,31 @@ BufferList.prototype.shallowSlice = function shallowSlice (start, end) {
   start = start || 0
   end = typeof end !== 'number' ? this.length : end
 
-  if (start < 0)
+  if (start < 0) {
     start += this.length
-  if (end < 0)
+  }
+
+  if (end < 0) {
     end += this.length
+  }
 
   if (start === end) {
     return this._new()
   }
-  var startOffset = this._offset(start)
-    , endOffset = this._offset(end)
-    , buffers = this._bufs.slice(startOffset[0], endOffset[0] + 1)
 
-  if (endOffset[1] == 0)
+  const startOffset = this._offset(start)
+  const endOffset = this._offset(end)
+  const buffers = this._bufs.slice(startOffset[0], endOffset[0] + 1)
+
+  if (endOffset[1] === 0) {
     buffers.pop()
-  else
-    buffers[buffers.length-1] = buffers[buffers.length-1].slice(0, endOffset[1])
+  } else {
+    buffers[buffers.length - 1] = buffers[buffers.length - 1].slice(0, endOffset[1])
+  }
 
-  if (startOffset[1] != 0)
+  if (startOffset[1] !== 0) {
     buffers[0] = buffers[0].slice(startOffset[1])
+  }
 
   return this._new(buffers)
 }
@@ -168,23 +198,21 @@ BufferList.prototype.consume = function consume (bytes) {
       break
     }
   }
+
   return this
 }
 
-
 BufferList.prototype.duplicate = function duplicate () {
-  var i = 0
-    , copy = this._new()
+  const copy = this._new()
 
-  for (; i < this._bufs.length; i++)
+  for (let i = 0; i < this._bufs.length; i++) {
     copy.append(this._bufs[i])
+  }
 
   return copy
 }
 
 BufferList.prototype.append = function append (buf) {
-  var i = 0
-
   if (buf == null) {
     return this
   }
@@ -193,17 +221,20 @@ BufferList.prototype.append = function append (buf) {
     // append a view of the underlying ArrayBuffer
     this._appendBuffer(Buffer.from(buf.buffer, buf.byteOffset, buf.byteLength))
   } else if (Array.isArray(buf)) {
-    for (; i < buf.length; i++)
+    for (let i = 0; i < buf.length; i++) {
       this.append(buf[i])
+    }
   } else if (this._isBufferList(buf)) {
     // unwrap argument into individual BufferLists
-    for (; i < buf._bufs.length; i++)
+    for (let i = 0; i < buf._bufs.length; i++) {
       this.append(buf._bufs[i])
+    }
   } else {
     // coerce number arguments to strings, since Buffer(number) does
     // uninitialized memory allocation
-    if (typeof buf == 'number')
+    if (typeof buf === 'number') {
       buf = buf.toString()
+    }
 
     this._appendBuffer(Buffer.from(buf))
   }
@@ -221,6 +252,7 @@ BufferList.prototype.indexOf = function (search, offset, encoding) {
     encoding = offset
     offset = undefined
   }
+
   if (typeof search === 'function' || Array.isArray(search)) {
     throw new TypeError('The "value" argument must be one of type string, Buffer, BufferList, or Uint8Array.')
   } else if (typeof search === 'number') {
@@ -236,6 +268,7 @@ BufferList.prototype.indexOf = function (search, offset, encoding) {
   }
 
   offset = Number(offset || 0)
+
   if (isNaN(offset)) {
     offset = 0
   }
@@ -252,31 +285,39 @@ BufferList.prototype.indexOf = function (search, offset, encoding) {
     return offset > this.length ? this.length : offset
   }
 
-  var blOffset = this._offset(offset)
-  var blIndex = blOffset[0] // index of which internal buffer we're working on
-  var buffOffset = blOffset[1] // offset of the internal buffer we're working on
+  const blOffset = this._offset(offset)
+  let blIndex = blOffset[0] // index of which internal buffer we're working on
+  let buffOffset = blOffset[1] // offset of the internal buffer we're working on
 
   // scan over each buffer
-  for (blIndex; blIndex < this._bufs.length; blIndex++) {
-    var buff = this._bufs[blIndex]
+  for (; blIndex < this._bufs.length; blIndex++) {
+    const buff = this._bufs[blIndex]
+
     while (buffOffset < buff.length) {
-      var availableWindow = buff.length - buffOffset
+      const availableWindow = buff.length - buffOffset
+
       if (availableWindow >= search.length) {
-        var nativeSearchResult = buff.indexOf(search, buffOffset)
+        const nativeSearchResult = buff.indexOf(search, buffOffset)
+
         if (nativeSearchResult !== -1) {
           return this._reverseOffset([blIndex, nativeSearchResult])
         }
+
         buffOffset = buff.length - search.length + 1 // end of native search window
       } else {
-        var revOffset = this._reverseOffset([blIndex, buffOffset])
+        const revOffset = this._reverseOffset([blIndex, buffOffset])
+
         if (this._match(revOffset, search)) {
           return revOffset
         }
+
         buffOffset++
       }
     }
+
     buffOffset = 0
   }
+
   return -1
 }
 
@@ -284,7 +325,8 @@ BufferList.prototype._match = function (offset, search) {
   if (this.length - offset < search.length) {
     return false
   }
-  for (var searchOffset = 0; searchOffset < search.length; searchOffset++) {
+
+  for (let searchOffset = 0; searchOffset < search.length; searchOffset++) {
     if (this.get(offset + searchOffset) !== search[searchOffset]) {
       return false
     }
@@ -293,28 +335,28 @@ BufferList.prototype._match = function (offset, search) {
 }
 
 ;(function () {
-  var methods = {
-      'readDoubleBE' : 8
-    , 'readDoubleLE' : 8
-    , 'readFloatBE'  : 4
-    , 'readFloatLE'  : 4
-    , 'readInt32BE'  : 4
-    , 'readInt32LE'  : 4
-    , 'readUInt32BE' : 4
-    , 'readUInt32LE' : 4
-    , 'readInt16BE'  : 2
-    , 'readInt16LE'  : 2
-    , 'readUInt16BE' : 2
-    , 'readUInt16LE' : 2
-    , 'readInt8'     : 1
-    , 'readUInt8'    : 1
-    , 'readIntBE'    : null
-    , 'readIntLE'    : null
-    , 'readUIntBE'   : null
-    , 'readUIntLE'   : null
+  const methods = {
+    readDoubleBE: 8,
+    readDoubleLE: 8,
+    readFloatBE: 4,
+    readFloatLE: 4,
+    readInt32BE: 4,
+    readInt32LE: 4,
+    readUInt32BE: 4,
+    readUInt32LE: 4,
+    readInt16BE: 2,
+    readInt16LE: 2,
+    readUInt16BE: 2,
+    readUInt16LE: 2,
+    readInt8: 1,
+    readUInt8: 1,
+    readIntBE: null,
+    readIntLE: null,
+    readUIntBE: null,
+    readUIntLE: null
   }
 
-  for (var m in methods) {
+  for (const m in methods) {
     (function (m) {
       if (methods[m] === null) {
         BufferList.prototype[m] = function (offset, byteLength) {

--- a/bl.js
+++ b/bl.js
@@ -1,16 +1,18 @@
 'use strict'
-var DuplexStream = require('readable-stream').Duplex
-  , util         = require('util')
-  , BufferList   = require('./BufferList')
+
+const DuplexStream = require('readable-stream').Duplex
+const util = require('util')
+const BufferList = require('./BufferList')
 
 function BufferListStream (callback) {
-  if (!(this instanceof BufferListStream))
+  if (!(this instanceof BufferListStream)) {
     return new BufferListStream(callback)
+  }
 
-  if (typeof callback == 'function') {
+  if (typeof callback === 'function') {
     this._callback = callback
 
-    var piper = function piper (err) {
+    const piper = function piper (err) {
       if (this._callback) {
         this._callback(err)
         this._callback = null
@@ -23,6 +25,7 @@ function BufferListStream (callback) {
     this.on('unpipe', function onUnpipe (src) {
       src.removeListener('error', piper)
     })
+
     callback = null
   }
 
@@ -40,13 +43,15 @@ BufferListStream.prototype._new = function _new (callback) {
 BufferListStream.prototype._write = function _write (buf, encoding, callback) {
   this._appendBuffer(buf)
 
-  if (typeof callback == 'function')
+  if (typeof callback === 'function') {
     callback()
+  }
 }
 
 BufferListStream.prototype._read = function _read (size) {
-  if (!this.length)
+  if (!this.length) {
     return this.push(null)
+  }
 
   size = Math.min(size, this.length)
   this.push(this.slice(0, size))

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Buffer List: collect buffers and access with a standard readable Buffer interface, streamable too!",
   "main": "bl.js",
   "scripts": {
-    "test": "node test/test.js | faucet"
+    "lint": "standard *.js test/*.js",
+    "test": "npm run lint && node test/test.js | faucet"
   },
   "repository": {
     "type": "git",
@@ -24,11 +25,11 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "readable-stream": "^3.0.1"
+    "readable-stream": "^3.4.0"
   },
   "devDependencies": {
-    "faucet": "0.0.1",
-    "hash_file": "~0.1.1",
-    "tape": "~4.9.1"
+    "faucet": "~0.0.1",
+    "standard": "^14.3.0",
+    "tape": "^4.11.0"
   }
 }

--- a/test/convert.js
+++ b/test/convert.js
@@ -4,7 +4,7 @@ const tape = require('tape')
 const { BufferList, BufferListStream } = require('../')
 const { Buffer } = require('safe-buffer')
 
-tape('convert from BufferList to BufferListStream', t => {
+tape('convert from BufferList to BufferListStream', (t) => {
   const data = Buffer.from(`TEST-${Date.now()}`)
   const bl = new BufferList(data)
   const bls = new BufferListStream(bl)
@@ -12,7 +12,7 @@ tape('convert from BufferList to BufferListStream', t => {
   t.end()
 })
 
-tape('convert from BufferListStream to BufferList', t => {
+tape('convert from BufferListStream to BufferList', (t) => {
   const data = Buffer.from(`TEST-${Date.now()}`)
   const bls = new BufferListStream(data)
   const bl = new BufferList(bls)

--- a/test/indexOf.js
+++ b/test/indexOf.js
@@ -1,69 +1,83 @@
 'use strict'
 
-var tape       = require('tape')
-  , BufferList = require('../')
-  , Buffer     = require('safe-buffer').Buffer
+const tape = require('tape')
+const BufferList = require('../')
+const Buffer = require('safe-buffer').Buffer
 
-tape('indexOf single byte needle', t => {
+tape('indexOf single byte needle', (t) => {
   const bl = new BufferList(['abcdefg', 'abcdefg', '12345'])
+
   t.equal(bl.indexOf('e'), 4)
   t.equal(bl.indexOf('e', 5), 11)
   t.equal(bl.indexOf('e', 12), -1)
   t.equal(bl.indexOf('5'), 18)
+
   t.end()
 })
 
-tape('indexOf multiple byte needle', t => {
+tape('indexOf multiple byte needle', (t) => {
   const bl = new BufferList(['abcdefg', 'abcdefg'])
+
   t.equal(bl.indexOf('ef'), 4)
   t.equal(bl.indexOf('ef', 5), 11)
+
   t.end()
 })
 
-tape('indexOf multiple byte needles across buffer boundaries', t => {
+tape('indexOf multiple byte needles across buffer boundaries', (t) => {
   const bl = new BufferList(['abcdefg', 'abcdefg'])
+
   t.equal(bl.indexOf('fgabc'), 5)
+
   t.end()
 })
 
-tape('indexOf takes a Uint8Array search', t => {
+tape('indexOf takes a Uint8Array search', (t) => {
   const bl = new BufferList(['abcdefg', 'abcdefg'])
   const search = new Uint8Array([102, 103, 97, 98, 99]) // fgabc
+
   t.equal(bl.indexOf(search), 5)
+
   t.end()
 })
 
-tape('indexOf takes a buffer list search', t => {
+tape('indexOf takes a buffer list search', (t) => {
   const bl = new BufferList(['abcdefg', 'abcdefg'])
   const search = new BufferList('fgabc')
+
   t.equal(bl.indexOf(search), 5)
+
   t.end()
 })
 
-tape('indexOf a zero byte needle', t => {
+tape('indexOf a zero byte needle', (t) => {
   const b = new BufferList('abcdef')
-  const buf_empty = Buffer.from('')
+  const bufEmpty = Buffer.from('')
+
   t.equal(b.indexOf(''), 0)
   t.equal(b.indexOf('', 1), 1)
   t.equal(b.indexOf('', b.length + 1), b.length)
   t.equal(b.indexOf('', Infinity), b.length)
-  t.equal(b.indexOf(buf_empty), 0)
-  t.equal(b.indexOf(buf_empty, 1), 1)
-  t.equal(b.indexOf(buf_empty, b.length + 1), b.length)
-  t.equal(b.indexOf(buf_empty, Infinity), b.length)
+  t.equal(b.indexOf(bufEmpty), 0)
+  t.equal(b.indexOf(bufEmpty, 1), 1)
+  t.equal(b.indexOf(bufEmpty, b.length + 1), b.length)
+  t.equal(b.indexOf(bufEmpty, Infinity), b.length)
+
   t.end()
 })
 
-tape('indexOf buffers smaller and larger than the needle', t => {
+tape('indexOf buffers smaller and larger than the needle', (t) => {
   const bl = new BufferList(['abcdefg', 'a', 'bcdefg', 'a', 'bcfgab'])
+
   t.equal(bl.indexOf('fgabc'), 5)
   t.equal(bl.indexOf('fgabc', 6), 12)
   t.equal(bl.indexOf('fgabc', 13), -1)
+
   t.end()
 })
 
 // only present in node 6+
-;(process.version.substr(1).split('.')[0] >= 6) && tape('indexOf latin1 and binary encoding', t => {
+;(process.version.substr(1).split('.')[0] >= 6) && tape('indexOf latin1 and binary encoding', (t) => {
   const b = new BufferList('abcdef')
 
   // test latin1 encoding
@@ -119,15 +133,16 @@ tape('indexOf buffers smaller and larger than the needle', t => {
       .indexOf(Buffer.from('\u00e8', 'binary'), 'binary'),
     0
   )
+
   t.end()
 })
 
-tape('indexOf the entire nodejs10 buffer test suite', t => {
+tape('indexOf the entire nodejs10 buffer test suite', (t) => {
   const b = new BufferList('abcdef')
-  const buf_a = Buffer.from('a')
-  const buf_bc = Buffer.from('bc')
-  const buf_f = Buffer.from('f')
-  const buf_z = Buffer.from('z')
+  const bufA = Buffer.from('a')
+  const bufBc = Buffer.from('bc')
+  const bufF = Buffer.from('f')
+  const bufZ = Buffer.from('z')
 
   const stringComparison = 'abcdef'
 
@@ -149,25 +164,26 @@ tape('indexOf the entire nodejs10 buffer test suite', t => {
   t.equal(b.indexOf('bc', Infinity), -1)
   t.equal(b.indexOf('f'), b.length - 1)
   t.equal(b.indexOf('z'), -1)
+
   // empty search tests
-  t.equal(b.indexOf(buf_a), 0)
-  t.equal(b.indexOf(buf_a, 1), -1)
-  t.equal(b.indexOf(buf_a, -1), -1)
-  t.equal(b.indexOf(buf_a, -4), -1)
-  t.equal(b.indexOf(buf_a, -b.length), 0)
-  t.equal(b.indexOf(buf_a, NaN), 0)
-  t.equal(b.indexOf(buf_a, -Infinity), 0)
-  t.equal(b.indexOf(buf_a, Infinity), -1)
-  t.equal(b.indexOf(buf_bc), 1)
-  t.equal(b.indexOf(buf_bc, 2), -1)
-  t.equal(b.indexOf(buf_bc, -1), -1)
-  t.equal(b.indexOf(buf_bc, -3), -1)
-  t.equal(b.indexOf(buf_bc, -5), 1)
-  t.equal(b.indexOf(buf_bc, NaN), 1)
-  t.equal(b.indexOf(buf_bc, -Infinity), 1)
-  t.equal(b.indexOf(buf_bc, Infinity), -1)
-  t.equal(b.indexOf(buf_f), b.length - 1)
-  t.equal(b.indexOf(buf_z), -1)
+  t.equal(b.indexOf(bufA), 0)
+  t.equal(b.indexOf(bufA, 1), -1)
+  t.equal(b.indexOf(bufA, -1), -1)
+  t.equal(b.indexOf(bufA, -4), -1)
+  t.equal(b.indexOf(bufA, -b.length), 0)
+  t.equal(b.indexOf(bufA, NaN), 0)
+  t.equal(b.indexOf(bufA, -Infinity), 0)
+  t.equal(b.indexOf(bufA, Infinity), -1)
+  t.equal(b.indexOf(bufBc), 1)
+  t.equal(b.indexOf(bufBc, 2), -1)
+  t.equal(b.indexOf(bufBc, -1), -1)
+  t.equal(b.indexOf(bufBc, -3), -1)
+  t.equal(b.indexOf(bufBc, -5), 1)
+  t.equal(b.indexOf(bufBc, NaN), 1)
+  t.equal(b.indexOf(bufBc, -Infinity), 1)
+  t.equal(b.indexOf(bufBc, Infinity), -1)
+  t.equal(b.indexOf(bufF), b.length - 1)
+  t.equal(b.indexOf(bufZ), -1)
   t.equal(b.indexOf(0x61), 0)
   t.equal(b.indexOf(0x61, 1), -1)
   t.equal(b.indexOf(0x61, -1), -1)
@@ -251,6 +267,7 @@ tape('indexOf the entire nodejs10 buffer test suite', t => {
 
   const mixedByteStringUcs2 =
       Buffer.from('\u039a\u0391abc\u03a3\u03a3\u0395', 'ucs2')
+
   t.equal(6, mixedByteStringUcs2.indexOf('bc', 0, 'ucs2'))
   t.equal(10, mixedByteStringUcs2.indexOf('\u03a3', 0, 'ucs2'))
   t.equal(-1, mixedByteStringUcs2.indexOf('\u0396', 0, 'ucs2'))
@@ -290,17 +307,17 @@ tape('indexOf the entire nodejs10 buffer test suite', t => {
   }
 
   const mixedByteStringUtf8 = Buffer.from('\u039a\u0391abc\u03a3\u03a3\u0395')
+
   t.equal(5, mixedByteStringUtf8.indexOf('bc'))
   t.equal(5, mixedByteStringUtf8.indexOf('bc', 5))
   t.equal(5, mixedByteStringUtf8.indexOf('bc', -8))
   t.equal(7, mixedByteStringUtf8.indexOf('\u03a3'))
   t.equal(-1, mixedByteStringUtf8.indexOf('\u0396'))
 
-
   // Test complex string indexOf algorithms. Only trigger for long strings.
   // Long string that isn't a simple repeat of a shorter string.
   let longString = 'A'
-  for (let i = 66; i < 76; i++) {  // from 'B' to 'K'
+  for (let i = 66; i < 76; i++) { // from 'B' to 'K'
     longString = longString + String.fromCharCode(i) + longString
   }
 
@@ -311,7 +328,7 @@ tape('indexOf the entire nodejs10 buffer test suite', t => {
   for (let i = 0; i < longBufferString.length - pattern.length; i += 7) {
     const index = longBufferString.indexOf(pattern, i)
     t.equal((i + 15) & ~0xf, index,
-                      `Long ABACABA...-string at index ${i}`)
+      `Long ABACABA...-string at index ${i}`)
   }
 
   let index = longBufferString.indexOf('AJABACA')
@@ -334,7 +351,10 @@ tape('indexOf the entire nodejs10 buffer test suite', t => {
 
   // Search in string containing many non-ASCII chars.
   const allCodePoints = []
-  for (let i = 0; i < 65536; i++) allCodePoints[i] = i
+  for (let i = 0; i < 65536; i++) {
+    allCodePoints[i] = i
+  }
+
   const allCharsString = String.fromCharCode.apply(String, allCodePoints)
   const allCharsBufferUtf8 = Buffer.from(allCharsString)
   const allCharsBufferUcs2 = Buffer.from(allCharsString, 'ucs2')
@@ -355,7 +375,7 @@ tape('indexOf the entire nodejs10 buffer test suite', t => {
 
   {
     // Find substrings in Utf8.
-    const lengths = [1, 3, 15];  // Single char, simple and complex.
+    const lengths = [1, 3, 15] // Single char, simple and complex.
     const indices = [0x5, 0x60, 0x400, 0x680, 0x7ee, 0xFF02, 0x16610, 0x2f77b]
     for (let lengthIndex = 0; lengthIndex < lengths.length; lengthIndex++) {
       for (let i = 0; i < indices.length; i++) {
@@ -385,8 +405,9 @@ tape('indexOf the entire nodejs10 buffer test suite', t => {
 
   {
     // Find substrings in Usc2.
-    const lengths = [2, 4, 16];  // Single char, simple and complex.
+    const lengths = [2, 4, 16] // Single char, simple and complex.
     const indices = [0x5, 0x65, 0x105, 0x205, 0x285, 0x2005, 0x2085, 0xfff0]
+
     for (let lengthIndex = 0; lengthIndex < lengths.length; lengthIndex++) {
       for (let i = 0; i < indices.length; i++) {
         const index = indices[i] * 2
@@ -408,8 +429,7 @@ tape('indexOf the entire nodejs10 buffer test suite', t => {
     () => {},
     {},
     []
-  ].forEach(val => {
-    debugger
+  ].forEach((val) => {
     t.throws(() => b.indexOf(val), TypeError, `"${JSON.stringify(val)}" should throw`)
   })
 
@@ -447,6 +467,7 @@ tape('indexOf the entire nodejs10 buffer test suite', t => {
   // test truncation of Number arguments to uint8
   {
     const buf = Buffer.from('this is a test')
+
     t.equal(buf.indexOf(0x6973), 3)
     t.equal(buf.indexOf(0x697320), 4)
     t.equal(buf.indexOf(0x69732069), 2)
@@ -462,9 +483,10 @@ tape('indexOf the entire nodejs10 buffer test suite', t => {
 
   // Test that Uint8Array arguments are okay.
   {
-    const needle = new Uint8Array([ 0x66, 0x6f, 0x6f ])
+    const needle = new Uint8Array([0x66, 0x6f, 0x6f])
     const haystack = new BufferList(Buffer.from('a foo b foo'))
     t.equal(haystack.indexOf(needle), 2)
   }
+
   t.end()
 })

--- a/test/isBufferList.js
+++ b/test/isBufferList.js
@@ -4,16 +4,15 @@ const tape = require('tape')
 const { BufferList, BufferListStream } = require('../')
 const { Buffer } = require('safe-buffer')
 
-tape('isBufferList positives', t => {
-  for (const obj of [
-    new BufferList(),
-    new BufferListStream()
-  ]) t.ok(BufferList.isBufferList(obj))
+tape('isBufferList positives', (t) => {
+  t.ok(BufferList.isBufferList(new BufferList()))
+  t.ok(BufferList.isBufferList(new BufferListStream()))
+
   t.end()
 })
 
-tape('isBufferList negatives', t => {
-  for (const obj of [
+tape('isBufferList negatives', (t) => {
+  const types = [
     null,
     undefined,
     NaN,
@@ -23,6 +22,11 @@ tape('isBufferList negatives', t => {
     [],
     Buffer.alloc(0),
     [Buffer.alloc(0)]
-  ]) t.notOk(BufferList.isBufferList(obj))
+  ]
+
+  for (const obj of types) {
+    t.notOk(BufferList.isBufferList(obj))
+  }
+
   t.end()
 })

--- a/test/test.js
+++ b/test/test.js
@@ -1,22 +1,23 @@
 'use strict'
 
-var tape       = require('tape')
-  , crypto     = require('crypto')
-  , fs         = require('fs')
-  , hash       = require('hash_file')
-  , BufferList = require('../')
-  , Buffer     = require('safe-buffer').Buffer
+const tape = require('tape')
+const crypto = require('crypto')
+const fs = require('fs')
+const path = require('path')
+const BufferList = require('../')
+const Buffer = require('safe-buffer').Buffer
 
-  , encodings  =
-      ('hex utf8 utf-8 ascii binary base64'
-          + (process.browser ? '' : ' ucs2 ucs-2 utf16le utf-16le')).split(' ')
+const encodings =
+      ('hex utf8 utf-8 ascii binary base64' +
+          (process.browser ? '' : ' ucs2 ucs-2 utf16le utf-16le')).split(' ')
 
 require('./indexOf')
 require('./isBufferList')
 require('./convert')
 
 tape('single bytes from single buffer', function (t) {
-  var bl = new BufferList()
+  const bl = new BufferList()
+
   bl.append(Buffer.from('abcd'))
 
   t.equal(bl.length, 4)
@@ -31,7 +32,8 @@ tape('single bytes from single buffer', function (t) {
 })
 
 tape('single bytes from multiple buffers', function (t) {
-  var bl = new BufferList()
+  const bl = new BufferList()
+
   bl.append(Buffer.from('abcd'))
   bl.append(Buffer.from('efg'))
   bl.append(Buffer.from('hi'))
@@ -49,11 +51,13 @@ tape('single bytes from multiple buffers', function (t) {
   t.equal(bl.get(7), 104)
   t.equal(bl.get(8), 105)
   t.equal(bl.get(9), 106)
+
   t.end()
 })
 
 tape('multi bytes from single buffer', function (t) {
-  var bl = new BufferList()
+  const bl = new BufferList()
+
   bl.append(Buffer.from('abcd'))
 
   t.equal(bl.length, 4)
@@ -67,7 +71,8 @@ tape('multi bytes from single buffer', function (t) {
 })
 
 tape('multi bytes from single buffer (negative indexes)', function (t) {
-  var bl = new BufferList()
+  const bl = new BufferList()
+
   bl.append(Buffer.from('buffer'))
 
   t.equal(bl.length, 6)
@@ -80,7 +85,7 @@ tape('multi bytes from single buffer (negative indexes)', function (t) {
 })
 
 tape('multiple bytes from multiple buffers', function (t) {
-  var bl = new BufferList()
+  const bl = new BufferList()
 
   bl.append(Buffer.from('abcd'))
   bl.append(Buffer.from('efg'))
@@ -100,10 +105,10 @@ tape('multiple bytes from multiple buffers', function (t) {
 })
 
 tape('multiple bytes from multiple buffer lists', function (t) {
-  var bl = new BufferList()
+  const bl = new BufferList()
 
-  bl.append(new BufferList([ Buffer.from('abcd'), Buffer.from('efg') ]))
-  bl.append(new BufferList([ Buffer.from('hi'), Buffer.from('j') ]))
+  bl.append(new BufferList([Buffer.from('abcd'), Buffer.from('efg')]))
+  bl.append(new BufferList([Buffer.from('hi'), Buffer.from('j')]))
 
   t.equal(bl.length, 10)
 
@@ -119,16 +124,16 @@ tape('multiple bytes from multiple buffer lists', function (t) {
 
 // same data as previous test, just using nested constructors
 tape('multiple bytes from crazy nested buffer lists', function (t) {
-  var bl = new BufferList()
+  const bl = new BufferList()
 
   bl.append(new BufferList([
-      new BufferList([
-          new BufferList(Buffer.from('abc'))
-        , Buffer.from('d')
-        , new BufferList(Buffer.from('efg'))
-      ])
-    , new BufferList([ Buffer.from('hi') ])
-    , new BufferList(Buffer.from('j'))
+    new BufferList([
+      new BufferList(Buffer.from('abc')),
+      Buffer.from('d'),
+      new BufferList(Buffer.from('efg'))
+    ]),
+    new BufferList([Buffer.from('hi')]),
+    new BufferList(Buffer.from('j'))
   ]))
 
   t.equal(bl.length, 10)
@@ -144,61 +149,69 @@ tape('multiple bytes from crazy nested buffer lists', function (t) {
 })
 
 tape('append accepts arrays of Buffers', function (t) {
-  var bl = new BufferList()
+  const bl = new BufferList()
+
   bl.append(Buffer.from('abc'))
-  bl.append([ Buffer.from('def') ])
-  bl.append([ Buffer.from('ghi'), Buffer.from('jkl') ])
-  bl.append([ Buffer.from('mnop'), Buffer.from('qrstu'), Buffer.from('vwxyz') ])
+  bl.append([Buffer.from('def')])
+  bl.append([Buffer.from('ghi'), Buffer.from('jkl')])
+  bl.append([Buffer.from('mnop'), Buffer.from('qrstu'), Buffer.from('vwxyz')])
   t.equal(bl.length, 26)
   t.equal(bl.slice().toString('ascii'), 'abcdefghijklmnopqrstuvwxyz')
+
   t.end()
 })
 
 tape('append accepts arrays of Uint8Arrays', function (t) {
-  var bl = new BufferList()
+  const bl = new BufferList()
 
   bl.append(new Uint8Array([97, 98, 99]))
-  bl.append([ Uint8Array.from([100, 101, 102]) ])
-  bl.append([ new Uint8Array([103, 104, 105]), new Uint8Array([106, 107, 108]) ])
-  bl.append([ new Uint8Array([109, 110, 111, 112]), new Uint8Array([113, 114, 115, 116, 117]), new Uint8Array([118, 119, 120, 121, 122]) ])
+  bl.append([Uint8Array.from([100, 101, 102])])
+  bl.append([new Uint8Array([103, 104, 105]), new Uint8Array([106, 107, 108])])
+  bl.append([new Uint8Array([109, 110, 111, 112]), new Uint8Array([113, 114, 115, 116, 117]), new Uint8Array([118, 119, 120, 121, 122])])
   t.equal(bl.length, 26)
   t.equal(bl.slice().toString('ascii'), 'abcdefghijklmnopqrstuvwxyz')
+
   t.end()
 })
 
 tape('append accepts arrays of BufferLists', function (t) {
-  var bl = new BufferList()
+  const bl = new BufferList()
+
   bl.append(Buffer.from('abc'))
-  bl.append([ new BufferList('def') ])
-  bl.append(new BufferList([ Buffer.from('ghi'), new BufferList('jkl') ]))
-  bl.append([ Buffer.from('mnop'), new BufferList([ Buffer.from('qrstu'), Buffer.from('vwxyz') ]) ])
+  bl.append([new BufferList('def')])
+  bl.append(new BufferList([Buffer.from('ghi'), new BufferList('jkl')]))
+  bl.append([Buffer.from('mnop'), new BufferList([Buffer.from('qrstu'), Buffer.from('vwxyz')])])
   t.equal(bl.length, 26)
   t.equal(bl.slice().toString('ascii'), 'abcdefghijklmnopqrstuvwxyz')
+
   t.end()
 })
 
 tape('append chainable', function (t) {
-  var bl = new BufferList()
+  const bl = new BufferList()
+
   t.ok(bl.append(Buffer.from('abcd')) === bl)
-  t.ok(bl.append([ Buffer.from('abcd') ]) === bl)
+  t.ok(bl.append([Buffer.from('abcd')]) === bl)
   t.ok(bl.append(new BufferList(Buffer.from('abcd'))) === bl)
-  t.ok(bl.append([ new BufferList(Buffer.from('abcd')) ]) === bl)
+  t.ok(bl.append([new BufferList(Buffer.from('abcd'))]) === bl)
+
   t.end()
 })
 
 tape('append chainable (test results)', function (t) {
-  var bl = new BufferList('abc')
-    .append([ new BufferList('def') ])
-    .append(new BufferList([ Buffer.from('ghi'), new BufferList('jkl') ]))
-    .append([ Buffer.from('mnop'), new BufferList([ Buffer.from('qrstu'), Buffer.from('vwxyz') ]) ])
+  const bl = new BufferList('abc')
+    .append([new BufferList('def')])
+    .append(new BufferList([Buffer.from('ghi'), new BufferList('jkl')]))
+    .append([Buffer.from('mnop'), new BufferList([Buffer.from('qrstu'), Buffer.from('vwxyz')])])
 
   t.equal(bl.length, 26)
   t.equal(bl.slice().toString('ascii'), 'abcdefghijklmnopqrstuvwxyz')
+
   t.end()
 })
 
 tape('consuming from multiple buffers', function (t) {
-  var bl = new BufferList()
+  const bl = new BufferList()
 
   bl.append(Buffer.from('abcd'))
   bl.append(Buffer.from('efg'))
@@ -233,7 +246,7 @@ tape('consuming from multiple buffers', function (t) {
 })
 
 tape('complete consumption', function (t) {
-  var bl = new BufferList()
+  const bl = new BufferList()
 
   bl.append(Buffer.from('a'))
   bl.append(Buffer.from('b'))
@@ -247,10 +260,10 @@ tape('complete consumption', function (t) {
 })
 
 tape('test readUInt8 / readInt8', function (t) {
-  var buf1 = Buffer.alloc(1)
-    , buf2 = Buffer.alloc(3)
-    , buf3 = Buffer.alloc(3)
-    , bl  = new BufferList()
+  const buf1 = Buffer.alloc(1)
+  const buf2 = Buffer.alloc(3)
+  const buf3 = Buffer.alloc(3)
+  const bl = new BufferList()
 
   buf2[1] = 0x3
   buf2[2] = 0x4
@@ -269,14 +282,15 @@ tape('test readUInt8 / readInt8', function (t) {
   t.equal(bl.readInt8(4), 0x23)
   t.equal(bl.readUInt8(5), 0x42)
   t.equal(bl.readInt8(5), 0x42)
+
   t.end()
 })
 
 tape('test readUInt16LE / readUInt16BE / readInt16LE / readInt16BE', function (t) {
-  var buf1 = Buffer.alloc(1)
-    , buf2 = Buffer.alloc(3)
-    , buf3 = Buffer.alloc(3)
-    , bl   = new BufferList()
+  const buf1 = Buffer.alloc(1)
+  const buf2 = Buffer.alloc(3)
+  const buf3 = Buffer.alloc(3)
+  const bl = new BufferList()
 
   buf2[1] = 0x3
   buf2[2] = 0x4
@@ -299,14 +313,15 @@ tape('test readUInt16LE / readUInt16BE / readInt16LE / readInt16BE', function (t
   t.equal(bl.readUInt16LE(4), 0x4223)
   t.equal(bl.readInt16BE(4), 0x2342)
   t.equal(bl.readInt16LE(4), 0x4223)
+
   t.end()
 })
 
 tape('test readUInt32LE / readUInt32BE / readInt32LE / readInt32BE', function (t) {
-  var buf1 = Buffer.alloc(1)
-    , buf2 = Buffer.alloc(3)
-    , buf3 = Buffer.alloc(3)
-    , bl   = new BufferList()
+  const buf1 = Buffer.alloc(1)
+  const buf2 = Buffer.alloc(3)
+  const buf3 = Buffer.alloc(3)
+  const bl = new BufferList()
 
   buf2[1] = 0x3
   buf2[2] = 0x4
@@ -321,14 +336,15 @@ tape('test readUInt32LE / readUInt32BE / readInt32LE / readInt32BE', function (t
   t.equal(bl.readUInt32LE(2), 0x42230403)
   t.equal(bl.readInt32BE(2), 0x03042342)
   t.equal(bl.readInt32LE(2), 0x42230403)
+
   t.end()
 })
 
 tape('test readUIntLE / readUIntBE / readIntLE / readIntBE', function (t) {
-  var buf1 = Buffer.alloc(1)
-    , buf2 = Buffer.alloc(3)
-    , buf3 = Buffer.alloc(3)
-    , bl   = new BufferList()
+  const buf1 = Buffer.alloc(1)
+  const buf2 = Buffer.alloc(3)
+  const buf3 = Buffer.alloc(3)
+  const bl = new BufferList()
 
   buf2[0] = 0x2
   buf2[1] = 0x3
@@ -365,14 +381,15 @@ tape('test readUIntLE / readUIntBE / readIntLE / readIntBE', function (t) {
   t.equal(bl.readIntLE(1, 4), 0x23040302)
   t.equal(bl.readIntLE(1, 5), 0x4223040302)
   t.equal(bl.readIntLE(1, 6), 0x614223040302)
+
   t.end()
 })
 
 tape('test readFloatLE / readFloatBE', function (t) {
-  var buf1 = Buffer.alloc(1)
-    , buf2 = Buffer.alloc(3)
-    , buf3 = Buffer.alloc(3)
-    , bl   = new BufferList()
+  const buf1 = Buffer.alloc(1)
+  const buf2 = Buffer.alloc(3)
+  const buf3 = Buffer.alloc(3)
+  const bl = new BufferList()
 
   buf2[1] = 0x00
   buf2[2] = 0x00
@@ -384,14 +401,15 @@ tape('test readFloatLE / readFloatBE', function (t) {
   bl.append(buf3)
 
   t.equal(bl.readFloatLE(2), 0x01)
+
   t.end()
 })
 
 tape('test readDoubleLE / readDoubleBE', function (t) {
-  var buf1 = Buffer.alloc(1)
-    , buf2 = Buffer.alloc(3)
-    , buf3 = Buffer.alloc(10)
-    , bl   = new BufferList()
+  const buf1 = Buffer.alloc(1)
+  const buf2 = Buffer.alloc(3)
+  const buf3 = Buffer.alloc(10)
+  const bl = new BufferList()
 
   buf2[1] = 0x55
   buf2[2] = 0x55
@@ -407,11 +425,12 @@ tape('test readDoubleLE / readDoubleBE', function (t) {
   bl.append(buf3)
 
   t.equal(bl.readDoubleLE(2), 0.3333333333333333)
+
   t.end()
 })
 
 tape('test toString', function (t) {
-  var bl = new BufferList()
+  const bl = new BufferList()
 
   bl.append(Buffer.from('abcd'))
   bl.append(Buffer.from('efg'))
@@ -428,8 +447,8 @@ tape('test toString', function (t) {
 })
 
 tape('test toString encoding', function (t) {
-  var bl = new BufferList()
-    , b  = Buffer.from('abcdefghij\xff\x00')
+  const bl = new BufferList()
+  const b = Buffer.from('abcdefghij\xff\x00')
 
   bl.append(Buffer.from('abcd'))
   bl.append(Buffer.from('efg'))
@@ -438,52 +457,54 @@ tape('test toString encoding', function (t) {
   bl.append(Buffer.from('\xff\x00'))
 
   encodings.forEach(function (enc) {
-      t.equal(bl.toString(enc), b.toString(enc), enc)
-    })
+    t.equal(bl.toString(enc), b.toString(enc), enc)
+  })
 
   t.end()
 })
 
 !process.browser && tape('test stream', function (t) {
-  var random = crypto.randomBytes(65534)
-    , rndhash = hash(random, 'md5')
-    , md5sum = crypto.createHash('md5')
-    , bl     = new BufferList(function (err, buf) {
-        t.ok(Buffer.isBuffer(buf))
-        t.ok(err === null)
-        t.equal(rndhash, hash(bl.slice(), 'md5'))
-        t.equal(rndhash, hash(buf, 'md5'))
+  const random = crypto.randomBytes(65534)
 
-        bl.pipe(fs.createWriteStream('/tmp/bl_test_rnd_out.dat'))
-          .on('close', function () {
-            var s = fs.createReadStream('/tmp/bl_test_rnd_out.dat')
-            s.on('data', md5sum.update.bind(md5sum))
-            s.on('end', function() {
-              t.equal(rndhash, md5sum.digest('hex'), 'woohoo! correct hash!')
-              t.end()
-            })
-          })
+  const bl = new BufferList((err, buf) => {
+    t.ok(Buffer.isBuffer(buf))
+    t.ok(err === null)
+    t.ok(random.equals(bl.slice()))
+    t.ok(random.equals(buf.slice()))
 
+    bl.pipe(fs.createWriteStream('/tmp/bl_test_rnd_out.dat'))
+      .on('close', function () {
+        const rndhash = crypto.createHash('md5').update(random).digest('hex')
+        const md5sum = crypto.createHash('md5')
+        const s = fs.createReadStream('/tmp/bl_test_rnd_out.dat')
+
+        s.on('data', md5sum.update.bind(md5sum))
+        s.on('end', function () {
+          t.equal(rndhash, md5sum.digest('hex'), 'woohoo! correct hash!')
+          t.end()
+        })
       })
+  })
 
   fs.writeFileSync('/tmp/bl_test_rnd.dat', random)
   fs.createReadStream('/tmp/bl_test_rnd.dat').pipe(bl)
 })
 
 tape('instantiation with Buffer', function (t) {
-  var buf  = crypto.randomBytes(1024)
-    , buf2 = crypto.randomBytes(1024)
-    , b    = BufferList(buf)
+  const buf = crypto.randomBytes(1024)
+  const buf2 = crypto.randomBytes(1024)
+  let b = BufferList(buf)
 
   t.equal(buf.toString('hex'), b.slice().toString('hex'), 'same buffer')
-  b = BufferList([ buf, buf2 ])
-  t.equal(b.slice().toString('hex'), Buffer.concat([ buf, buf2 ]).toString('hex'), 'same buffer')
+  b = BufferList([buf, buf2])
+  t.equal(b.slice().toString('hex'), Buffer.concat([buf, buf2]).toString('hex'), 'same buffer')
+
   t.end()
 })
 
 tape('test String appendage', function (t) {
-  var bl = new BufferList()
-    , b  = Buffer.from('abcdefghij\xff\x00')
+  const bl = new BufferList()
+  const b = Buffer.from('abcdefghij\xff\x00')
 
   bl.append('abcd')
   bl.append('efg')
@@ -492,15 +513,15 @@ tape('test String appendage', function (t) {
   bl.append('\xff\x00')
 
   encodings.forEach(function (enc) {
-      t.equal(bl.toString(enc), b.toString(enc))
-    })
+    t.equal(bl.toString(enc), b.toString(enc))
+  })
 
   t.end()
 })
 
 tape('test Number appendage', function (t) {
-  var bl = new BufferList()
-    , b  = Buffer.from('1234567890')
+  const bl = new BufferList()
+  const b = Buffer.from('1234567890')
 
   bl.append(1234)
   bl.append(567)
@@ -508,8 +529,8 @@ tape('test Number appendage', function (t) {
   bl.append(0)
 
   encodings.forEach(function (enc) {
-      t.equal(bl.toString(enc), b.toString(enc))
-    })
+    t.equal(bl.toString(enc), b.toString(enc))
+  })
 
   t.end()
 })
@@ -526,10 +547,12 @@ tape('write nothing, should get empty buffer', function (t) {
 
 tape('unicode string', function (t) {
   t.plan(2)
-  var inp1 = '\u2600'
-    , inp2 = '\u2603'
-    , exp = inp1 + ' and ' + inp2
-    , bl = BufferList()
+
+  const inp1 = '\u2600'
+  const inp2 = '\u2603'
+  const exp = inp1 + ' and ' + inp2
+  const bl = BufferList()
+
   bl.write(inp1)
   bl.write(' and ')
   bl.write(inp2)
@@ -538,8 +561,8 @@ tape('unicode string', function (t) {
 })
 
 tape('should emit finish', function (t) {
-  var source = BufferList()
-    , dest = BufferList()
+  const source = BufferList()
+  const dest = BufferList()
 
   source.write('hello')
   source.pipe(dest)
@@ -551,90 +574,100 @@ tape('should emit finish', function (t) {
 })
 
 tape('basic copy', function (t) {
-  var buf  = crypto.randomBytes(1024)
-    , buf2 = Buffer.alloc(1024)
-    , b    = BufferList(buf)
+  const buf = crypto.randomBytes(1024)
+  const buf2 = Buffer.alloc(1024)
+  const b = BufferList(buf)
 
   b.copy(buf2)
   t.equal(b.slice().toString('hex'), buf2.toString('hex'), 'same buffer')
+
   t.end()
 })
 
 tape('copy after many appends', function (t) {
-  var buf  = crypto.randomBytes(512)
-    , buf2 = Buffer.alloc(1024)
-    , b    = BufferList(buf)
+  const buf = crypto.randomBytes(512)
+  const buf2 = Buffer.alloc(1024)
+  const b = BufferList(buf)
 
   b.append(buf)
   b.copy(buf2)
   t.equal(b.slice().toString('hex'), buf2.toString('hex'), 'same buffer')
+
   t.end()
 })
 
 tape('copy at a precise position', function (t) {
-  var buf  = crypto.randomBytes(1004)
-    , buf2 = Buffer.alloc(1024)
-    , b    = BufferList(buf)
+  const buf = crypto.randomBytes(1004)
+  const buf2 = Buffer.alloc(1024)
+  const b = BufferList(buf)
 
   b.copy(buf2, 20)
   t.equal(b.slice().toString('hex'), buf2.slice(20).toString('hex'), 'same buffer')
+
   t.end()
 })
 
 tape('copy starting from a precise location', function (t) {
-  var buf  = crypto.randomBytes(10)
-    , buf2 = Buffer.alloc(5)
-    , b    = BufferList(buf)
+  const buf = crypto.randomBytes(10)
+  const buf2 = Buffer.alloc(5)
+  const b = BufferList(buf)
 
   b.copy(buf2, 0, 5)
   t.equal(b.slice(5).toString('hex'), buf2.toString('hex'), 'same buffer')
+
   t.end()
 })
 
 tape('copy in an interval', function (t) {
-  var rnd      = crypto.randomBytes(10)
-    , b        = BufferList(rnd) // put the random bytes there
-    , actual   = Buffer.alloc(3)
-    , expected = Buffer.alloc(3)
+  const rnd = crypto.randomBytes(10)
+  const b = BufferList(rnd) // put the random bytes there
+  const actual = Buffer.alloc(3)
+  const expected = Buffer.alloc(3)
 
   rnd.copy(expected, 0, 5, 8)
   b.copy(actual, 0, 5, 8)
 
   t.equal(actual.toString('hex'), expected.toString('hex'), 'same buffer')
+
   t.end()
 })
 
 tape('copy an interval between two buffers', function (t) {
-  var buf      = crypto.randomBytes(10)
-    , buf2     = Buffer.alloc(10)
-    , b        = BufferList(buf)
+  const buf = crypto.randomBytes(10)
+  const buf2 = Buffer.alloc(10)
+  const b = BufferList(buf)
 
   b.append(buf)
   b.copy(buf2, 0, 5, 15)
 
   t.equal(b.slice(5, 15).toString('hex'), buf2.toString('hex'), 'same buffer')
+
   t.end()
 })
 
 tape('shallow slice across buffer boundaries', function (t) {
-  var bl = new BufferList(['First', 'Second', 'Third'])
+  const bl = new BufferList(['First', 'Second', 'Third'])
 
   t.equal(bl.shallowSlice(3, 13).toString(), 'stSecondTh')
+
   t.end()
 })
 
 tape('shallow slice within single buffer', function (t) {
   t.plan(2)
-  var bl = new BufferList(['First', 'Second', 'Third'])
+
+  const bl = new BufferList(['First', 'Second', 'Third'])
 
   t.equal(bl.shallowSlice(5, 10).toString(), 'Secon')
   t.equal(bl.shallowSlice(7, 10).toString(), 'con')
+
   t.end()
 })
 
 tape('shallow slice single buffer', function (t) {
   t.plan(3)
-  var bl = new BufferList(['First', 'Second', 'Third'])
+
+  const bl = new BufferList(['First', 'Second', 'Third'])
 
   t.equal(bl.shallowSlice(0, 5).toString(), 'First')
   t.equal(bl.shallowSlice(5, 11).toString(), 'Second')
@@ -643,7 +676,8 @@ tape('shallow slice single buffer', function (t) {
 
 tape('shallow slice with negative or omitted indices', function (t) {
   t.plan(4)
-  var bl = new BufferList(['First', 'Second', 'Third'])
+
+  const bl = new BufferList(['First', 'Second', 'Third'])
 
   t.equal(bl.shallowSlice().toString(), 'FirstSecondThird')
   t.equal(bl.shallowSlice(5).toString(), 'SecondThird')
@@ -653,8 +687,9 @@ tape('shallow slice with negative or omitted indices', function (t) {
 
 tape('shallow slice does not make a copy', function (t) {
   t.plan(1)
-  var buffers = [Buffer.from('First'), Buffer.from('Second'), Buffer.from('Third')]
-  var bl = (new BufferList(buffers)).shallowSlice(5, -3)
+
+  const buffers = [Buffer.from('First'), Buffer.from('Second'), Buffer.from('Third')]
+  const bl = (new BufferList(buffers)).shallowSlice(5, -3)
 
   buffers[1].fill('h')
   buffers[2].fill('h')
@@ -664,23 +699,27 @@ tape('shallow slice does not make a copy', function (t) {
 
 tape('shallow slice with 0 length', function (t) {
   t.plan(1)
-  var buffers = [Buffer.from('First'), Buffer.from('Second'), Buffer.from('Third')]
-  var bl = (new BufferList(buffers)).shallowSlice(0, 0)
+
+  const buffers = [Buffer.from('First'), Buffer.from('Second'), Buffer.from('Third')]
+  const bl = (new BufferList(buffers)).shallowSlice(0, 0)
+
   t.equal(bl.length, 0)
 })
 
 tape('shallow slice with 0 length from middle', function (t) {
   t.plan(1)
-  var buffers = [Buffer.from('First'), Buffer.from('Second'), Buffer.from('Third')]
-  var bl = (new BufferList(buffers)).shallowSlice(10, 10)
+
+  const buffers = [Buffer.from('First'), Buffer.from('Second'), Buffer.from('Third')]
+  const bl = (new BufferList(buffers)).shallowSlice(10, 10)
+
   t.equal(bl.length, 0)
 })
 
 tape('duplicate', function (t) {
   t.plan(2)
 
-  var bl = new BufferList('abcdefghij\xff\x00')
-    , dup = bl.duplicate()
+  const bl = new BufferList('abcdefghij\xff\x00')
+  const dup = bl.duplicate()
 
   t.equal(bl.prototype, dup.prototype)
   t.equal(bl.toString('hex'), dup.toString('hex'))
@@ -689,7 +728,8 @@ tape('duplicate', function (t) {
 tape('destroy no pipe', function (t) {
   t.plan(2)
 
-  var bl = new BufferList('alsdkfja;lsdkfja;lsdk')
+  const bl = new BufferList('alsdkfja;lsdkfja;lsdk')
+
   bl.destroy()
 
   t.equal(bl._bufs.length, 0)
@@ -699,8 +739,9 @@ tape('destroy no pipe', function (t) {
 tape('destroy with error', function (t) {
   t.plan(3)
 
-  var bl = new BufferList('alsdkfja;lsdkfja;lsdk')
-  var err = new Error('kaboom')
+  const bl = new BufferList('alsdkfja;lsdkfja;lsdk')
+  const err = new Error('kaboom')
+
   bl.destroy(err)
   bl.on('error', function (_err) {
     t.equal(_err, err)
@@ -713,22 +754,22 @@ tape('destroy with error', function (t) {
 !process.browser && tape('destroy with pipe before read end', function (t) {
   t.plan(2)
 
-  var bl = new BufferList()
-  fs.createReadStream(__dirname + '/test.js')
+  const bl = new BufferList()
+  fs.createReadStream(path.join(__dirname, '/test.js'))
     .pipe(bl)
 
   bl.destroy()
 
   t.equal(bl._bufs.length, 0)
   t.equal(bl.length, 0)
-
 })
 
 !process.browser && tape('destroy with pipe before read end with race', function (t) {
   t.plan(2)
 
-  var bl = new BufferList()
-  fs.createReadStream(__dirname + '/test.js')
+  const bl = new BufferList()
+
+  fs.createReadStream(path.join(__dirname, '/test.js'))
     .pipe(bl)
 
   setTimeout(function () {
@@ -743,8 +784,9 @@ tape('destroy with error', function (t) {
 !process.browser && tape('destroy with pipe after read end', function (t) {
   t.plan(2)
 
-  var bl = new BufferList()
-  fs.createReadStream(__dirname + '/test.js')
+  const bl = new BufferList()
+
+  fs.createReadStream(path.join(__dirname, '/test.js'))
     .on('end', onEnd)
     .pipe(bl)
 
@@ -759,10 +801,10 @@ tape('destroy with error', function (t) {
 !process.browser && tape('destroy with pipe while writing to a destination', function (t) {
   t.plan(4)
 
-  var bl = new BufferList()
-    , ds = new BufferList()
+  const bl = new BufferList()
+  const ds = new BufferList()
 
-  fs.createReadStream(__dirname + '/test.js')
+  fs.createReadStream(path.join(__dirname, '/test.js'))
     .on('end', onEnd)
     .pipe(bl)
 
@@ -779,13 +821,13 @@ tape('destroy with error', function (t) {
 
       t.equals(bl._bufs.length, 0)
       t.equals(bl.length, 0)
-
     }, 100)
   }
 })
 
 !process.browser && tape('handle error', function (t) {
   t.plan(2)
+
   fs.createReadStream('/does/not/exist').pipe(BufferList(function (err, data) {
     t.ok(err instanceof Error, 'has error')
     t.notOk(data, 'no data')


### PR DESCRIPTION
Also includes the changes in #74, so the last commit is the new thing here.

`standard` is hooked up for `"lint"` and `"test"`. I've also done some additional formatting fixes, mainly adding newlines and whitespace. The style should be easier to grok now and `standard` is getting pretty comprehensive so that should help with contributions.

Proposing that this gets released as 4.0.0. There's nothing strictly breaking in here if you're using it as documented but it does feel like the safe choice.