### PR TITLE
fix: dont rely in node globals

### DIFF
--- a/BufferList.js
+++ b/BufferList.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { Buffer } = require('buffer')
 const symbol = Symbol.for('BufferList')
 
 function BufferList (buf) {

--- a/bl.js
+++ b/bl.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const DuplexStream = require('readable-stream').Duplex
-const util = require('util')
+const inherits = require('inherits')
 const BufferList = require('./BufferList')
 
 function BufferListStream (callback) {
@@ -33,7 +33,7 @@ function BufferListStream (callback) {
   DuplexStream.call(this)
 }
 
-util.inherits(BufferListStream, DuplexStream)
+inherits(BufferListStream, DuplexStream)
 Object.assign(BufferListStream.prototype, BufferList.prototype)
 
 BufferListStream.prototype._new = function _new (callback) {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "buffer": "^5.5.0",
+    "inherits": "^2.0.4",
     "readable-stream": "^3.4.0"
   },
   "devDependencies": {

--- a/test/convert.js
+++ b/test/convert.js
@@ -2,7 +2,7 @@
 
 const tape = require('tape')
 const { BufferList, BufferListStream } = require('../')
-const { Buffer } = require('safe-buffer')
+const { Buffer } = require('buffer')
 
 tape('convert from BufferList to BufferListStream', (t) => {
   const data = Buffer.from(`TEST-${Date.now()}`)

--- a/test/indexOf.js
+++ b/test/indexOf.js
@@ -2,7 +2,7 @@
 
 const tape = require('tape')
 const BufferList = require('../')
-const Buffer = require('safe-buffer').Buffer
+const { Buffer } = require('buffer')
 
 tape('indexOf single byte needle', (t) => {
   const bl = new BufferList(['abcdefg', 'abcdefg', '12345'])

--- a/test/isBufferList.js
+++ b/test/isBufferList.js
@@ -2,7 +2,7 @@
 
 const tape = require('tape')
 const { BufferList, BufferListStream } = require('../')
-const { Buffer } = require('safe-buffer')
+const { Buffer } = require('buffer')
 
 tape('isBufferList positives', (t) => {
   t.ok(BufferList.isBufferList(new BufferList()))

--- a/test/test.js
+++ b/test/test.js
@@ -5,7 +5,7 @@ const crypto = require('crypto')
 const fs = require('fs')
 const path = require('path')
 const BufferList = require('../')
-const Buffer = require('safe-buffer').Buffer
+const { Buffer } = require('buffer')
 
 const encodings =
       ('hex utf8 utf-8 ascii binary base64' +


### PR DESCRIPTION
This PR removes the dependency on node globals, so the users don't need to rely on browser bundlers magic.

related to https://github.com/ipfs/js-ipfs/issues/2924