### PR TITLE
Specify files to publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,5 +34,9 @@
     "faucet": "~0.0.1",
     "standard": "^14.3.0",
     "tape": "^4.11.0"
-  }
+  },
+  "files": [
+    "bl.js",
+    "BufferList.js"
+  ]
 }


### PR DESCRIPTION
Currently the `test` directory is also being published to `npm`. Considering that it makes up almost half of the filesize of this package, it would be worthwhile to not publish it. This PR does this using the [`files`](https://docs.npmjs.com/files/package.json#files) field in the `package.json`. 