### PR TITLE
fix: duplicate license field

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "stream",
     "awesomesauce"
   ],
-  "license": "MIT",
   "dependencies": {
     "buffer": "^5.5.0",
     "inherits": "^2.0.4",


### PR DESCRIPTION
In my logs I saw this
```
warning: Duplicate key: "license"
```

So here is the quick fix 😉 