### PR TITLE
Feature/typescript integrated typings

### DIFF
--- a/BufferList.d.ts
+++ b/BufferList.d.ts
@@ -1,0 +1,379 @@
+export type BufferListInitData =
+  | Buffer
+  | Buffer[]
+  | BufferList
+  | BufferList[]
+  | string;
+
+export interface BufferListConstructor {
+  new (initData?: BufferListInitData): BufferList;
+  (initData?: BufferListInitData): BufferList;
+
+  /**
+   * Determines if the passed object is a BufferList. It will return true
+   * if the passed object is an instance of BufferList or BufferListStream
+   * and false otherwise.
+   *
+   * N.B. this won't return true for BufferList or BufferListStream instances
+   * created by versions of this library before this static method was added.
+   *
+   * @param other
+   */
+
+  isBufferList(other: unknown): boolean;
+}
+
+interface BufferList {
+  /**
+   * Get the length of the list in bytes. This is the sum of the lengths
+   * of all of the buffers contained in the list, minus any initial offset
+   * for a semi-consumed buffer at the beginning. Should accurately
+   * represent the total number of bytes that can be read from the list.
+   */
+
+  length: number;
+
+  /**
+   * Adds an additional buffer or BufferList to the internal list.
+   * this is returned so it can be chained.
+   *
+   * @param buffer
+   */
+
+  append(buffer: Buffer | Buffer[] | BufferList | BufferList[] | string): this;
+
+  /**
+   * Will return the byte at the specified index.
+   * @param index
+   */
+
+  get(index: number): number;
+
+  /**
+   * Returns a new Buffer object containing the bytes within the
+   * range specified. Both start and end are optional and will
+   * default to the beginning and end of the list respectively.
+   *
+   * If the requested range spans a single internal buffer then a
+   * slice of that buffer will be returned which shares the original
+   * memory range of that Buffer. If the range spans multiple buffers
+   * then copy operations will likely occur to give you a uniform Buffer.
+   *
+   * @param start
+   * @param end
+   */
+
+  slice(start?: number, end?: number): Buffer;
+
+  /**
+   * Returns a new BufferList object containing the bytes within the
+   * range specified. Both start and end are optional and will default
+   * to the beginning and end of the list respectively.
+   *
+   * No copies will be performed. All buffers in the result share
+   * memory with the original list.
+   *
+   * @param start
+   * @param end
+   */
+
+  shallowSlice(start?: number, end?: number): this;
+
+  /**
+   * Copies the content of the list in the `dest` buffer, starting from
+   * `destStart` and containing the bytes within the range specified
+   * with `srcStart` to `srcEnd`.
+   *
+   * `destStart`, `start` and `end` are optional and will default to the
+   * beginning of the dest buffer, and the beginning and end of the
+   * list respectively.
+   *
+   * @param dest
+   * @param destStart
+   * @param srcStart
+   * @param srcEnd
+   */
+
+  copy(
+    dest: Buffer,
+    destStart?: number,
+    srcStart?: number,
+    srcEnd?: number
+  ): Buffer;
+
+  /**
+   * Performs a shallow-copy of the list. The internal Buffers remains the
+   * same, so if you change the underlying Buffers, the change will be
+   * reflected in both the original and the duplicate.
+   *
+   * This method is needed if you want to call consume() or pipe() and
+   * still keep the original list.
+   *
+   * @example
+   *
+   * ```js
+   * var bl = new BufferListStream();
+   * bl.append('hello');
+   * bl.append(' world');
+   * bl.append('\n');
+   * bl.duplicate().pipe(process.stdout, { end: false });
+   *
+   * console.log(bl.toString())
+   * ```
+   */
+
+  duplicate(): this;
+
+  /**
+   * Will shift bytes off the start of the list. The number of bytes
+   * consumed don't need to line up with the sizes of the internal
+   * Buffers—initial offsets will be calculated accordingly in order
+   * to give you a consistent view of the data.
+   *
+   * @param bytes
+   */
+
+  consume(bytes?: number): void;
+
+  /**
+   * Will return a string representation of the buffer. The optional
+   * `start` and `end` arguments are passed on to `slice()`, while
+   * the encoding is passed on to `toString()` of the resulting Buffer.
+   *
+   * See the [`Buffer#toString()`](http://nodejs.org/docs/latest/api/buffer.html#buffer_buf_tostring_encoding_start_end)
+   * documentation for more information.
+   *
+   * @param encoding
+   * @param start
+   * @param end
+   */
+
+  toString(encoding?: string, start?: number, end?: number): string;
+
+  /**
+   * Will return the byte at the specified index. indexOf() method
+   * returns the first index at which a given element can be found
+   * in the BufferList, or -1 if it is not present.
+   *
+   * @param value
+   * @param byteOffset
+   * @param encoding
+   */
+
+  indexOf(
+    value: string | number | Uint8Array | BufferList | Buffer,
+    byteOffset?: number,
+    encoding?: string
+  ): number;
+
+  /**
+   * All of the standard byte-reading methods of the Buffer interface are implemented and will operate across internal Buffer boundaries transparently.
+   * See the [Buffer](http://nodejs.org/docs/latest/api/buffer.html) documentation for how these work.
+   *
+   * @param offset
+   */
+
+  readDoubleBE(offset?: number): number;
+
+  /**
+   * All of the standard byte-reading methods of the Buffer interface are implemented and will operate across internal Buffer boundaries transparently.
+   * See the [Buffer](http://nodejs.org/docs/latest/api/buffer.html) documentation for how these work.
+   *
+   * @param offset
+   */
+
+  readDoubleLE(offset?: number): number;
+
+  /**
+   * All of the standard byte-reading methods of the Buffer interface are implemented and will operate across internal Buffer boundaries transparently.
+   * See the [Buffer](http://nodejs.org/docs/latest/api/buffer.html) documentation for how these work.
+   *
+   * @param offset
+   */
+
+  readFloatBE(offset?: number): number;
+
+  /**
+   * All of the standard byte-reading methods of the Buffer interface are implemented and will operate across internal Buffer boundaries transparently.
+   * See the [Buffer](http://nodejs.org/docs/latest/api/buffer.html) documentation for how these work.
+   *
+   * @param offset
+   */
+
+  readFloatLE(offset?: number): number;
+
+  /**
+   * All of the standard byte-reading methods of the Buffer interface are implemented and will operate across internal Buffer boundaries transparently.
+   * See the [Buffer](http://nodejs.org/docs/latest/api/buffer.html) documentation for how these work.
+   *
+   * @param offset
+   */
+
+  readInt32BE(offset?: number): number;
+
+  /**
+   * All of the standard byte-reading methods of the Buffer interface are implemented and will operate across internal Buffer boundaries transparently.
+   * See the [Buffer](http://nodejs.org/docs/latest/api/buffer.html) documentation for how these work.
+   *
+   * @param offset
+   */
+
+  readInt32LE(offset?: number): number;
+
+  /**
+   * All of the standard byte-reading methods of the Buffer interface are implemented and will operate across internal Buffer boundaries transparently.
+   * See the [Buffer](http://nodejs.org/docs/latest/api/buffer.html) documentation for how these work.
+   *
+   * @param offset
+   */
+
+  readUInt32BE(offset?: number): number;
+
+  /**
+   * All of the standard byte-reading methods of the Buffer interface are implemented and will operate across internal Buffer boundaries transparently.
+   * See the [Buffer](http://nodejs.org/docs/latest/api/buffer.html) documentation for how these work.
+   *
+   * @param offset
+   */
+
+  readUInt32LE(offset?: number): number;
+
+  /**
+   * All of the standard byte-reading methods of the Buffer interface are implemented and will operate across internal Buffer boundaries transparently.
+   * See the [Buffer](http://nodejs.org/docs/latest/api/buffer.html) documentation for how these work.
+   *
+   * @param offset
+   */
+
+  readInt16BE(offset?: number): number;
+
+  /**
+   * All of the standard byte-reading methods of the Buffer interface are
+   * implemented and will operate across internal Buffer boundaries transparently.
+   *
+   * See the [Buffer](http://nodejs.org/docs/latest/api/buffer.html)
+   * documentation for how these work.
+   *
+   * @param offset
+   */
+
+  readInt16LE(offset?: number): number;
+
+  /**
+   * All of the standard byte-reading methods of the Buffer interface are
+   * implemented and will operate across internal Buffer boundaries transparently.
+   *
+   * See the [Buffer](http://nodejs.org/docs/latest/api/buffer.html)
+   * documentation for how these work.
+   *
+   * @param offset
+   */
+
+  readUInt16BE(offset?: number): number;
+
+  /**
+   * All of the standard byte-reading methods of the Buffer interface are
+   * implemented and will operate across internal Buffer boundaries transparently.
+   *
+   * See the [Buffer](http://nodejs.org/docs/latest/api/buffer.html)
+   * documentation for how these work.
+   *
+   * @param offset
+   */
+
+  readUInt16LE(offset?: number): number;
+
+  /**
+   * All of the standard byte-reading methods of the Buffer interface are
+   * implemented and will operate across internal Buffer boundaries transparently.
+   *
+   * See the [Buffer](http://nodejs.org/docs/latest/api/buffer.html)
+   * documentation for how these work.
+   *
+   * @param offset
+   */
+
+  readInt8(offset: number): number;
+
+  /**
+   * All of the standard byte-reading methods of the Buffer interface are
+   * implemented and will operate across internal Buffer boundaries transparently.
+   *
+   * See the [Buffer](http://nodejs.org/docs/latest/api/buffer.html)
+   * documentation for how these work.
+   *
+   * @param offset
+   */
+
+  readUInt8(offset: number): number;
+
+  /**
+   * All of the standard byte-reading methods of the Buffer interface are
+   * implemented and will operate across internal Buffer boundaries transparently.
+   *
+   * See the [Buffer](http://nodejs.org/docs/latest/api/buffer.html)
+   * documentation for how these work.
+   *
+   * @param offset
+   */
+
+  readIntBE(offset: number): number;
+
+  /**
+   * All of the standard byte-reading methods of the Buffer interface are
+   * implemented and will operate across internal Buffer boundaries transparently.
+   *
+   * See the [Buffer](http://nodejs.org/docs/latest/api/buffer.html)
+   * documentation for how these work.
+   *
+   * @param offset
+   */
+
+  readIntLE(offset: number): number;
+
+  /**
+   * All of the standard byte-reading methods of the Buffer interface are
+   * implemented and will operate across internal Buffer boundaries transparently.
+   *
+   * See the [Buffer](http://nodejs.org/docs/latest/api/buffer.html)
+   * documentation for how these work.
+   *
+   * @param offset
+   */
+
+  readUIntBE(offset: number): number;
+
+  /**
+   * All of the standard byte-reading methods of the Buffer interface are
+   * implemented and will operate across internal Buffer boundaries transparently.
+   *
+   * See the [Buffer](http://nodejs.org/docs/latest/api/buffer.html)
+   * documentation for how these work.
+   *
+   * @param offset
+   */
+
+  readUIntLE(offset: number): number;
+}
+
+/**
+ * No arguments are required for the constructor, but you can initialise
+ * the list by passing in a single Buffer object or an array of Buffer
+ * objects.
+ *
+ * `new` is not strictly required, if you don't instantiate a new object,
+ * it will be done automatically for you so you can create a new instance
+ * simply with:
+ *
+ * ```js
+ * const { BufferList } = require('bl')
+ * const bl = BufferList()
+ *
+ * // equivalent to:
+ *
+ * const { BufferList } = require('bl')
+ * const bl = new BufferList()
+ * ```
+ */
+
+declare const BufferList: BufferListConstructor;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,66 @@
+import type { Duplex } from "readable-stream";
+import type { BufferList, BufferListInitData } from "./BufferList";
+
+export * from "./BufferList";
+
+type BufferListStreamInit =
+  | ((err: Error, buffer: Buffer) => void)
+  | BufferListInitData;
+
+interface BufferListStreamConstructor {
+  new (initData?: BufferListStreamInit): BufferListStream;
+  (callback?: BufferListStreamInit): BufferListStream;
+
+  /**
+   * Determines if the passed object is a BufferList. It will return true
+   * if the passed object is an instance of BufferList or BufferListStream
+   * and false otherwise.
+   *
+   * N.B. this won't return true for BufferList or BufferListStream instances
+   * created by versions of this library before this static method was added.
+   *
+   * @param other
+   */
+
+  isBufferList(other: unknown): boolean;
+}
+
+/** Type Entrypoint */
+export interface BufferListStream extends Duplex, BufferList {}
+
+/**
+ * BufferListStream is a Node Duplex Stream, so it can be read from
+ * and written to like a standard Node stream. You can also pipe()
+ * to and from a BufferListStream instance.
+ *
+ * The constructor takes an optional callback, if supplied, the
+ * callback will be called with an error argument followed by a
+ * reference to the bl instance, when bl.end() is called
+ * (i.e. from a piped stream).
+ *
+ * This is a convenient method of collecting the entire contents of
+ * a stream, particularly when the stream is chunky, such as a network
+ * stream.
+ *
+ * Normally, no arguments are required for the constructor, but you can
+ * initialise the list by passing in a single Buffer object or an array
+ * of Buffer object.
+ *
+ * `new` is not strictly required, if you don't instantiate a new object,
+ * it will be done automatically for you so you can create a new instance
+ *
+ * simply with:
+ *
+ * ```js
+ * const { BufferListStream } = require('bl');
+ * const bl = BufferListStream();
+ *
+ * // equivalent to:
+ *
+ * const { BufferListStream } = require('bl');
+ * const bl = new BufferListStream();
+ * ```
+ */
+
+export const BufferListStream: BufferListStreamConstructor;
+export default BufferListStream;

--- a/index.d.ts
+++ b/index.d.ts
@@ -25,7 +25,6 @@ interface BufferListStreamConstructor {
   isBufferList(other: unknown): boolean;
 }
 
-/** Type Entrypoint */
 export interface BufferListStream extends Duplex, BufferList {}
 
 /**
@@ -48,7 +47,6 @@ export interface BufferListStream extends Duplex, BufferList {}
  *
  * `new` is not strictly required, if you don't instantiate a new object,
  * it will be done automatically for you so you can create a new instance
- *
  * simply with:
  *
  * ```js
@@ -60,7 +58,19 @@ export interface BufferListStream extends Duplex, BufferList {}
  * const { BufferListStream } = require('bl');
  * const bl = new BufferListStream();
  * ```
+ *
+ * N.B. For backwards compatibility reasons, BufferListStream is the default
+ * export when you `require('bl')`:
+ *
+ * ```js
+ * const { BufferListStream } = require('bl')
+ *
+ * // equivalent to:
+ *
+ * const BufferListStream = require('bl')
+ * ```
  */
 
 export const BufferListStream: BufferListStreamConstructor;
 export default BufferListStream;
+export = BufferListStream;

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "readable-stream": "^3.4.0"
   },
   "devDependencies": {
+    "@types/readable-stream": "^2.3.13",
     "faucet": "~0.0.1",
     "standard": "^16.0.3",
     "tape": "^5.2.2"


### PR DESCRIPTION
Hello there, I'm working on a migration to Typescript of a library that uses a very old version of `bl` (`v1.2.3` - which, for unknown reasons, is unlisted on NPM to me, but still accessible via URL).

I'm not a very huge fan of DefinitelyTyped but I _DefinitelyLove_ Typescript. Also, I was looking at `@types/bl`, and they seemed a bit wrong to me, based on the implementation.

So I decided to rewrite them with a better structure to represent how the code was written (in fact `interfaces` allow to specify of both a constructor and a function to be executed) and inside the package.

Now all the methods include a documentation comment based on the one in the Readme.

Hope this is appreciated. I also tried to run the tests available inside `@types/bl`, and they seem to be okay, and run linting.

I hope this is appreciated. Let me know if there's anything that you feel is wrong, and I'll _feeex_ it! 🛠️ 