### PR TITLE
Added bigint (Int64) support.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+## [5.1.0](https://github.com/rvagg/bl/compare/v5.0.0...v5.1.0) (2022-10-18)
+
+
+### Features
+
+* added integrated TypeScript typings ([#108](https://github.com/rvagg/bl/issues/108)) ([433ff89](https://github.com/rvagg/bl/commit/433ff8942f47fab8a5c9d13b2c00989ccf8d0710))
+
+
+### Bug Fixes
+
+* windows support in tests ([387dfaf](https://github.com/rvagg/bl/commit/387dfaf9b2bca7849f12785436ceb01e42adac2c))
+
+
+### Trivial Changes
+
+* GH Actions, Dependabot, auto-release, remove Travis ([997f058](https://github.com/rvagg/bl/commit/997f058357de8f2a7f66998e80a72b491835573f))
+* **no-release:** bump standard from 16.0.4 to 17.0.0 ([#112](https://github.com/rvagg/bl/issues/112)) ([078bfe3](https://github.com/rvagg/bl/commit/078bfe33390d125297b1c946e5989c4aa9228961))

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lint": "standard *.js test/*.js",
     "test": "npm run lint && npm run test:types && node test/test.js | faucet",
     "test:ci": "npm run lint && node test/test.js && npm run test:types",
-    "test:types": "tsc --target esnext --moduleResolution node --allowJs --noEmit test/test.js",
+    "test:types": "tsc --allowJs --moduleResolution node --noEmit --target esnext test/test.js",
     "build": "true"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bl",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "description": "Buffer List: collect buffers and access with a standard readable Buffer interface, streamable too!",
   "license": "MIT",
   "main": "bl.js",

--- a/test/test.js
+++ b/test/test.js
@@ -1,13 +1,15 @@
 // @ts-check
 'use strict'
 
-const tape = require('tape')
+const { Buffer } = require('buffer')
 const crypto = require('crypto')
 const fs = require('fs')
-const path = require('path')
 const os = require('os')
+const path = require('path')
+
+const tape = require('tape')
+
 const BufferListStream = require('../')
-const { Buffer } = require('buffer')
 
 /**
  * This typedef allows us to add _bufs to the API without declaring it publicly on types.


### PR DESCRIPTION
Updated PR from https://github.com/rvagg/bl/pull/87


* Add default read offsets for Node Buffer compatibility

This PR adds an optional offset to the `readXX` methods to create compatibility with the Node Buffer API https://nodejs.org/api/buffer.html#buffer_buf_readbigint64be_offset

* Added tests

* test udpate