### PR TITLE
Added prettier

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,9 @@
+{
+  "semi": false,
+  "singleQuote": true,
+  "useTabs": false,
+  "tabWidth": 2,
+  "trailingComma": "es5",
+  "bracketSameLine": true,
+  "endOfLine": "lf"
+}

--- a/BufferList.d.ts
+++ b/BufferList.d.ts
@@ -4,11 +4,11 @@ export type BufferListAcceptedTypes =
   | Uint8Array
   | BufferListAcceptedTypes[]
   | string
-  | number;
+  | number
 
 export interface BufferListConstructor {
-  new (initData?: BufferListAcceptedTypes): BufferList;
-  (initData?: BufferListAcceptedTypes): BufferList;
+  new (initData?: BufferListAcceptedTypes): BufferList
+  (initData?: BufferListAcceptedTypes): BufferList
 
   /**
    * Determines if the passed object is a BufferList. It will return true
@@ -21,7 +21,7 @@ export interface BufferListConstructor {
    * @param other
    */
 
-  isBufferList(other: unknown): boolean;
+  isBufferList(other: unknown): boolean
 }
 
 interface BufferList {
@@ -34,7 +34,7 @@ interface BufferList {
    * represent the total number of bytes that can be read from the list.
    */
 
-  length: number;
+  length: number
 
   /**
    * Adds an additional buffer or BufferList to the internal list.
@@ -43,14 +43,14 @@ interface BufferList {
    * @param buffer
    */
 
-  append(buffer: BufferListAcceptedTypes): this;
+  append(buffer: BufferListAcceptedTypes): this
 
   /**
    * Will return the byte at the specified index.
    * @param index
    */
 
-  get(index: number): number;
+  get(index: number): number
 
   /**
    * Returns a new Buffer object containing the bytes within the
@@ -66,7 +66,7 @@ interface BufferList {
    * @param end
    */
 
-  slice(start?: number, end?: number): Buffer;
+  slice(start?: number, end?: number): Buffer
 
   /**
    * Returns a new BufferList object containing the bytes within the
@@ -80,7 +80,7 @@ interface BufferList {
    * @param end
    */
 
-  shallowSlice(start?: number, end?: number): this;
+  shallowSlice(start?: number, end?: number): this
 
   /**
    * Copies the content of the list in the `dest` buffer, starting from
@@ -102,7 +102,7 @@ interface BufferList {
     destStart?: number,
     srcStart?: number,
     srcEnd?: number
-  ): Buffer;
+  ): Buffer
 
   /**
    * Performs a shallow-copy of the list. The internal Buffers remains the
@@ -125,7 +125,7 @@ interface BufferList {
    * ```
    */
 
-  duplicate(): this;
+  duplicate(): this
 
   /**
    * Will shift bytes off the start of the list. The number of bytes
@@ -136,7 +136,7 @@ interface BufferList {
    * @param bytes
    */
 
-  consume(bytes?: number): void;
+  consume(bytes?: number): void
 
   /**
    * Will return a string representation of the buffer. The optional
@@ -151,7 +151,7 @@ interface BufferList {
    * @param end
    */
 
-  toString(encoding?: string, start?: number, end?: number): string;
+  toString(encoding?: string, start?: number, end?: number): string
 
   /**
    * Will return the byte at the specified index. indexOf() method
@@ -167,7 +167,7 @@ interface BufferList {
     value: string | number | Uint8Array | BufferList | Buffer,
     byteOffset?: number,
     encoding?: string
-  ): number;
+  ): number
 
   /**
    * All of the standard byte-reading methods of the Buffer interface are implemented and will operate across internal Buffer boundaries transparently.
@@ -176,7 +176,7 @@ interface BufferList {
    * @param offset
    */
 
-  readDoubleBE: Buffer['readDoubleBE'];
+  readDoubleBE: Buffer['readDoubleBE']
 
   /**
    * All of the standard byte-reading methods of the Buffer interface are implemented and will operate across internal Buffer boundaries transparently.
@@ -185,7 +185,7 @@ interface BufferList {
    * @param offset
    */
 
-  readDoubleLE: Buffer['readDoubleLE'];
+  readDoubleLE: Buffer['readDoubleLE']
 
   /**
    * All of the standard byte-reading methods of the Buffer interface are implemented and will operate across internal Buffer boundaries transparently.
@@ -194,7 +194,7 @@ interface BufferList {
    * @param offset
    */
 
-  readFloatBE: Buffer['readFloatBE'];
+  readFloatBE: Buffer['readFloatBE']
 
   /**
    * All of the standard byte-reading methods of the Buffer interface are implemented and will operate across internal Buffer boundaries transparently.
@@ -203,7 +203,7 @@ interface BufferList {
    * @param offset
    */
 
-  readFloatLE: Buffer['readFloatLE'];
+  readFloatLE: Buffer['readFloatLE']
 
   /**
    * All of the standard byte-reading methods of the Buffer interface are implemented and will operate across internal Buffer boundaries transparently.
@@ -212,7 +212,7 @@ interface BufferList {
    * @param offset
    */
 
-  readInt32BE: Buffer['readInt32BE'];
+  readInt32BE: Buffer['readInt32BE']
 
   /**
    * All of the standard byte-reading methods of the Buffer interface are implemented and will operate across internal Buffer boundaries transparently.
@@ -221,7 +221,7 @@ interface BufferList {
    * @param offset
    */
 
-  readInt32LE: Buffer['readInt32LE'];
+  readInt32LE: Buffer['readInt32LE']
 
   /**
    * All of the standard byte-reading methods of the Buffer interface are implemented and will operate across internal Buffer boundaries transparently.
@@ -230,7 +230,7 @@ interface BufferList {
    * @param offset
    */
 
-  readUInt32BE: Buffer['readUInt32BE'];
+  readUInt32BE: Buffer['readUInt32BE']
 
   /**
    * All of the standard byte-reading methods of the Buffer interface are implemented and will operate across internal Buffer boundaries transparently.
@@ -239,7 +239,7 @@ interface BufferList {
    * @param offset
    */
 
-  readUInt32LE: Buffer['readUInt32LE'];
+  readUInt32LE: Buffer['readUInt32LE']
 
   /**
    * All of the standard byte-reading methods of the Buffer interface are implemented and will operate across internal Buffer boundaries transparently.
@@ -248,7 +248,7 @@ interface BufferList {
    * @param offset
    */
 
-  readInt16BE: Buffer['readInt16BE'];
+  readInt16BE: Buffer['readInt16BE']
 
   /**
    * All of the standard byte-reading methods of the Buffer interface are
@@ -260,7 +260,7 @@ interface BufferList {
    * @param offset
    */
 
-  readInt16LE: Buffer['readInt16LE'];
+  readInt16LE: Buffer['readInt16LE']
 
   /**
    * All of the standard byte-reading methods of the Buffer interface are
@@ -272,7 +272,7 @@ interface BufferList {
    * @param offset
    */
 
-  readUInt16BE: Buffer['readUInt16BE'];
+  readUInt16BE: Buffer['readUInt16BE']
 
   /**
    * All of the standard byte-reading methods of the Buffer interface are
@@ -284,7 +284,7 @@ interface BufferList {
    * @param offset
    */
 
-  readUInt16LE: Buffer['readUInt16LE'];
+  readUInt16LE: Buffer['readUInt16LE']
 
   /**
    * All of the standard byte-reading methods of the Buffer interface are
@@ -296,7 +296,7 @@ interface BufferList {
    * @param offset
    */
 
-  readInt8: Buffer['readInt8'];
+  readInt8: Buffer['readInt8']
 
   /**
    * All of the standard byte-reading methods of the Buffer interface are
@@ -308,7 +308,7 @@ interface BufferList {
    * @param offset
    */
 
-  readUInt8: Buffer['readUInt8'];
+  readUInt8: Buffer['readUInt8']
 
   /**
    * All of the standard byte-reading methods of the Buffer interface are
@@ -320,7 +320,7 @@ interface BufferList {
    * @param offset
    */
 
-  readIntBE: Buffer['readIntBE'];
+  readIntBE: Buffer['readIntBE']
 
   /**
    * All of the standard byte-reading methods of the Buffer interface are
@@ -332,7 +332,7 @@ interface BufferList {
    * @param offset
    */
 
-  readIntLE: Buffer['readIntLE'];
+  readIntLE: Buffer['readIntLE']
 
   /**
    * All of the standard byte-reading methods of the Buffer interface are
@@ -344,7 +344,7 @@ interface BufferList {
    * @param offset
    */
 
-  readUIntBE: Buffer['readUIntBE'];
+  readUIntBE: Buffer['readUIntBE']
 
   /**
    * All of the standard byte-reading methods of the Buffer interface are
@@ -356,7 +356,7 @@ interface BufferList {
    * @param offset
    */
 
-  readUIntLE: Buffer['readUIntLE'];
+  readUIntLE: Buffer['readUIntLE']
 }
 
 /**
@@ -379,4 +379,4 @@ interface BufferList {
  * ```
  */
 
-declare const BufferList: BufferListConstructor;
+declare const BufferList: BufferListConstructor

--- a/BufferList.js
+++ b/BufferList.js
@@ -3,7 +3,7 @@
 const { Buffer } = require('buffer')
 const symbol = Symbol.for('BufferList')
 
-function BufferList (buf) {
+function BufferList(buf) {
   if (!(this instanceof BufferList)) {
     return new BufferList(buf)
   }
@@ -11,7 +11,7 @@ function BufferList (buf) {
   BufferList._init.call(this, buf)
 }
 
-BufferList._init = function _init (buf) {
+BufferList._init = function _init(buf) {
   Object.defineProperty(this, symbol, { value: true })
 
   this._bufs = []
@@ -22,11 +22,11 @@ BufferList._init = function _init (buf) {
   }
 }
 
-BufferList.prototype._new = function _new (buf) {
+BufferList.prototype._new = function _new(buf) {
   return new BufferList(buf)
 }
 
-BufferList.prototype._offset = function _offset (offset) {
+BufferList.prototype._offset = function _offset(offset) {
   if (offset === 0) {
     return [0, 0]
   }
@@ -53,7 +53,7 @@ BufferList.prototype._reverseOffset = function (blOffset) {
   return offset
 }
 
-BufferList.prototype.get = function get (index) {
+BufferList.prototype.get = function get(index) {
   if (index > this.length || index < 0) {
     return undefined
   }
@@ -63,7 +63,7 @@ BufferList.prototype.get = function get (index) {
   return this._bufs[offset[0]][offset[1]]
 }
 
-BufferList.prototype.slice = function slice (start, end) {
+BufferList.prototype.slice = function slice(start, end) {
   if (typeof start === 'number' && start < 0) {
     start += this.length
   }
@@ -75,7 +75,7 @@ BufferList.prototype.slice = function slice (start, end) {
   return this.copy(null, 0, start, end)
 }
 
-BufferList.prototype.copy = function copy (dst, dstStart, srcStart, srcEnd) {
+BufferList.prototype.copy = function copy(dst, dstStart, srcStart, srcEnd) {
   if (typeof srcStart !== 'number' || srcStart < 0) {
     srcStart = 0
   }
@@ -154,7 +154,7 @@ BufferList.prototype.copy = function copy (dst, dstStart, srcStart, srcEnd) {
   return dst
 }
 
-BufferList.prototype.shallowSlice = function shallowSlice (start, end) {
+BufferList.prototype.shallowSlice = function shallowSlice(start, end) {
   start = start || 0
   end = typeof end !== 'number' ? this.length : end
 
@@ -177,7 +177,10 @@ BufferList.prototype.shallowSlice = function shallowSlice (start, end) {
   if (endOffset[1] === 0) {
     buffers.pop()
   } else {
-    buffers[buffers.length - 1] = buffers[buffers.length - 1].slice(0, endOffset[1])
+    buffers[buffers.length - 1] = buffers[buffers.length - 1].slice(
+      0,
+      endOffset[1]
+    )
   }
 
   if (startOffset[1] !== 0) {
@@ -187,11 +190,11 @@ BufferList.prototype.shallowSlice = function shallowSlice (start, end) {
   return this._new(buffers)
 }
 
-BufferList.prototype.toString = function toString (encoding, start, end) {
+BufferList.prototype.toString = function toString(encoding, start, end) {
   return this.slice(start, end).toString(encoding)
 }
 
-BufferList.prototype.consume = function consume (bytes) {
+BufferList.prototype.consume = function consume(bytes) {
   // first, normalize the argument, in accordance with how Buffer does it
   bytes = Math.trunc(bytes)
   // do nothing if not a positive number
@@ -212,7 +215,7 @@ BufferList.prototype.consume = function consume (bytes) {
   return this
 }
 
-BufferList.prototype.duplicate = function duplicate () {
+BufferList.prototype.duplicate = function duplicate() {
   const copy = this._new()
 
   for (let i = 0; i < this._bufs.length; i++) {
@@ -222,7 +225,7 @@ BufferList.prototype.duplicate = function duplicate () {
   return copy
 }
 
-BufferList.prototype.append = function append (buf) {
+BufferList.prototype.append = function append(buf) {
   if (buf == null) {
     return this
   }
@@ -252,7 +255,7 @@ BufferList.prototype.append = function append (buf) {
   return this
 }
 
-BufferList.prototype._appendBuffer = function appendBuffer (buf) {
+BufferList.prototype._appendBuffer = function appendBuffer(buf) {
   this._bufs.push(buf)
   this.length += buf.length
 }
@@ -264,7 +267,9 @@ BufferList.prototype.indexOf = function (search, offset, encoding) {
   }
 
   if (typeof search === 'function' || Array.isArray(search)) {
-    throw new TypeError('The "value" argument must be one of type string, Buffer, BufferList, or Uint8Array.')
+    throw new TypeError(
+      'The "value" argument must be one of type string, Buffer, BufferList, or Uint8Array.'
+    )
   } else if (typeof search === 'number') {
     search = Buffer.from([search])
   } else if (typeof search === 'string') {
@@ -343,7 +348,6 @@ BufferList.prototype._match = function (offset, search) {
   }
   return true
 }
-
 ;(function () {
   const methods = {
     readDoubleBE: 8,
@@ -363,11 +367,11 @@ BufferList.prototype._match = function (offset, search) {
     readIntBE: null,
     readIntLE: null,
     readUIntBE: null,
-    readUIntLE: null
+    readUIntLE: null,
   }
 
   for (const m in methods) {
-    (function (m) {
+    ;(function (m) {
       if (methods[m] === null) {
         BufferList.prototype[m] = function (offset, byteLength) {
           return this.slice(offset, offset + byteLength)[m](0, byteLength)
@@ -377,19 +381,19 @@ BufferList.prototype._match = function (offset, search) {
           return this.slice(offset, offset + methods[m])[m](0)
         }
       }
-    }(m))
+    })(m)
   }
-}())
+})()
 
 // Used internally by the class and also as an indicator of this object being
 // a `BufferList`. It's not possible to use `instanceof BufferList` in a browser
 // environment because there could be multiple different copies of the
 // BufferList class and some `BufferList`s might be `BufferList`s.
-BufferList.prototype._isBufferList = function _isBufferList (b) {
+BufferList.prototype._isBufferList = function _isBufferList(b) {
   return b instanceof BufferList || BufferList.isBufferList(b)
 }
 
-BufferList.isBufferList = function isBufferList (b) {
+BufferList.isBufferList = function isBufferList(b) {
   return b != null && b[symbol]
 }
 

--- a/bl.js
+++ b/bl.js
@@ -4,7 +4,7 @@ const DuplexStream = require('readable-stream').Duplex
 const inherits = require('inherits')
 const BufferList = require('./BufferList')
 
-function BufferListStream (callback) {
+function BufferListStream(callback) {
   if (!(this instanceof BufferListStream)) {
     return new BufferListStream(callback)
   }
@@ -12,17 +12,17 @@ function BufferListStream (callback) {
   if (typeof callback === 'function') {
     this._callback = callback
 
-    const piper = function piper (err) {
+    const piper = function piper(err) {
       if (this._callback) {
         this._callback(err)
         this._callback = null
       }
     }.bind(this)
 
-    this.on('pipe', function onPipe (src) {
+    this.on('pipe', function onPipe(src) {
       src.on('error', piper)
     })
-    this.on('unpipe', function onUnpipe (src) {
+    this.on('unpipe', function onUnpipe(src) {
       src.removeListener('error', piper)
     })
 
@@ -36,11 +36,11 @@ function BufferListStream (callback) {
 inherits(BufferListStream, DuplexStream)
 Object.assign(BufferListStream.prototype, BufferList.prototype)
 
-BufferListStream.prototype._new = function _new (callback) {
+BufferListStream.prototype._new = function _new(callback) {
   return new BufferListStream(callback)
 }
 
-BufferListStream.prototype._write = function _write (buf, encoding, callback) {
+BufferListStream.prototype._write = function _write(buf, encoding, callback) {
   this._appendBuffer(buf)
 
   if (typeof callback === 'function') {
@@ -48,7 +48,7 @@ BufferListStream.prototype._write = function _write (buf, encoding, callback) {
   }
 }
 
-BufferListStream.prototype._read = function _read (size) {
+BufferListStream.prototype._read = function _read(size) {
   if (!this.length) {
     return this.push(null)
   }
@@ -58,7 +58,7 @@ BufferListStream.prototype._read = function _read (size) {
   this.consume(size)
 }
 
-BufferListStream.prototype.end = function end (chunk) {
+BufferListStream.prototype.end = function end(chunk) {
   DuplexStream.prototype.end.call(this, chunk)
 
   if (this._callback) {
@@ -67,14 +67,18 @@ BufferListStream.prototype.end = function end (chunk) {
   }
 }
 
-BufferListStream.prototype._destroy = function _destroy (err, cb) {
+BufferListStream.prototype._destroy = function _destroy(err, cb) {
   this._bufs.length = 0
   this.length = 0
   cb(err)
 }
 
-BufferListStream.prototype._isBufferList = function _isBufferList (b) {
-  return b instanceof BufferListStream || b instanceof BufferList || BufferListStream.isBufferList(b)
+BufferListStream.prototype._isBufferList = function _isBufferList(b) {
+  return (
+    b instanceof BufferListStream ||
+    b instanceof BufferList ||
+    BufferListStream.isBufferList(b)
+  )
 }
 
 BufferListStream.isBufferList = BufferList.isBufferList

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,17 +1,17 @@
-import { Duplex } from "readable-stream";
+import { Duplex } from 'readable-stream'
 import {
   BufferList as BL,
   BufferListConstructor,
   BufferListAcceptedTypes,
-} from "./BufferList";
+} from './BufferList'
 
 type BufferListStreamInit =
   | ((err: Error, buffer: Buffer) => void)
-  | BufferListAcceptedTypes;
+  | BufferListAcceptedTypes
 
 interface BufferListStreamConstructor {
-  new (initData?: BufferListStreamInit): BufferListStream;
-  (callback?: BufferListStreamInit): BufferListStream;
+  new (initData?: BufferListStreamInit): BufferListStream
+  (callback?: BufferListStreamInit): BufferListStream
 
   /**
    * Determines if the passed object is a BufferList. It will return true
@@ -24,19 +24,19 @@ interface BufferListStreamConstructor {
    * @param other
    */
 
-  isBufferList(other: unknown): boolean;
+  isBufferList(other: unknown): boolean
 
   /**
    * Rexporting BufferList and BufferListStream to fix
    * issue with require/commonjs import and "export = " below.
    */
 
-  BufferList: BufferListConstructor;
-  BufferListStream: BufferListStreamConstructor;
+  BufferList: BufferListConstructor
+  BufferListStream: BufferListStreamConstructor
 }
 
 interface BufferListStream extends Duplex, BL {
-  prototype: BufferListStream & BL;
+  prototype: BufferListStream & BL
 }
 
 /**
@@ -83,6 +83,6 @@ interface BufferListStream extends Duplex, BL {
  * ```
  */
 
-declare const BufferListStream: BufferListStreamConstructor;
+declare const BufferListStream: BufferListStreamConstructor
 
-export = BufferListStream;
+export = BufferListStream

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "devDependencies": {
     "@types/readable-stream": "^2.3.13",
     "faucet": "~0.0.1",
+    "prettier": "^2.7.1",
     "standard": "^17.0.0",
     "tape": "^5.2.2",
     "typescript": "~4.7.3"

--- a/test/indexOf.js
+++ b/test/indexOf.js
@@ -77,65 +77,90 @@ tape('indexOf buffers smaller and larger than the needle', (t) => {
 })
 
 // only present in node 6+
-;(process.version.substr(1).split('.')[0] >= 6) && tape('indexOf latin1 and binary encoding', (t) => {
-  const b = new BufferList('abcdef')
+process.version.substr(1).split('.')[0] >= 6 &&
+  tape('indexOf latin1 and binary encoding', (t) => {
+    const b = new BufferList('abcdef')
 
-  // test latin1 encoding
-  t.equal(
-    new BufferList(Buffer.from(b.toString('latin1'), 'latin1'))
-      .indexOf('d', 0, 'latin1'),
-    3
-  )
-  t.equal(
-    new BufferList(Buffer.from(b.toString('latin1'), 'latin1'))
-      .indexOf(Buffer.from('d', 'latin1'), 0, 'latin1'),
-    3
-  )
-  t.equal(
-    new BufferList(Buffer.from('aa\u00e8aa', 'latin1'))
-      .indexOf('\u00e8', 'latin1'),
-    2
-  )
-  t.equal(
-    new BufferList(Buffer.from('\u00e8', 'latin1'))
-      .indexOf('\u00e8', 'latin1'),
-    0
-  )
-  t.equal(
-    new BufferList(Buffer.from('\u00e8', 'latin1'))
-      .indexOf(Buffer.from('\u00e8', 'latin1'), 'latin1'),
-    0
-  )
+    // test latin1 encoding
+    t.equal(
+      new BufferList(Buffer.from(b.toString('latin1'), 'latin1')).indexOf(
+        'd',
+        0,
+        'latin1'
+      ),
+      3
+    )
+    t.equal(
+      new BufferList(Buffer.from(b.toString('latin1'), 'latin1')).indexOf(
+        Buffer.from('d', 'latin1'),
+        0,
+        'latin1'
+      ),
+      3
+    )
+    t.equal(
+      new BufferList(Buffer.from('aa\u00e8aa', 'latin1')).indexOf(
+        '\u00e8',
+        'latin1'
+      ),
+      2
+    )
+    t.equal(
+      new BufferList(Buffer.from('\u00e8', 'latin1')).indexOf(
+        '\u00e8',
+        'latin1'
+      ),
+      0
+    )
+    t.equal(
+      new BufferList(Buffer.from('\u00e8', 'latin1')).indexOf(
+        Buffer.from('\u00e8', 'latin1'),
+        'latin1'
+      ),
+      0
+    )
 
-  // test binary encoding
-  t.equal(
-    new BufferList(Buffer.from(b.toString('binary'), 'binary'))
-      .indexOf('d', 0, 'binary'),
-    3
-  )
-  t.equal(
-    new BufferList(Buffer.from(b.toString('binary'), 'binary'))
-      .indexOf(Buffer.from('d', 'binary'), 0, 'binary'),
-    3
-  )
-  t.equal(
-    new BufferList(Buffer.from('aa\u00e8aa', 'binary'))
-      .indexOf('\u00e8', 'binary'),
-    2
-  )
-  t.equal(
-    new BufferList(Buffer.from('\u00e8', 'binary'))
-      .indexOf('\u00e8', 'binary'),
-    0
-  )
-  t.equal(
-    new BufferList(Buffer.from('\u00e8', 'binary'))
-      .indexOf(Buffer.from('\u00e8', 'binary'), 'binary'),
-    0
-  )
+    // test binary encoding
+    t.equal(
+      new BufferList(Buffer.from(b.toString('binary'), 'binary')).indexOf(
+        'd',
+        0,
+        'binary'
+      ),
+      3
+    )
+    t.equal(
+      new BufferList(Buffer.from(b.toString('binary'), 'binary')).indexOf(
+        Buffer.from('d', 'binary'),
+        0,
+        'binary'
+      ),
+      3
+    )
+    t.equal(
+      new BufferList(Buffer.from('aa\u00e8aa', 'binary')).indexOf(
+        '\u00e8',
+        'binary'
+      ),
+      2
+    )
+    t.equal(
+      new BufferList(Buffer.from('\u00e8', 'binary')).indexOf(
+        '\u00e8',
+        'binary'
+      ),
+      0
+    )
+    t.equal(
+      new BufferList(Buffer.from('\u00e8', 'binary')).indexOf(
+        Buffer.from('\u00e8', 'binary'),
+        'binary'
+      ),
+      0
+    )
 
-  t.end()
-})
+    t.end()
+  })
 
 tape('indexOf the entire nodejs10 buffer test suite', (t) => {
   const b = new BufferList('abcdef')
@@ -214,38 +239,38 @@ tape('indexOf the entire nodejs10 buffer test suite', (t) => {
   t.throws(() => b.indexOf('bad', 'enc'), TypeError)
 
   // test hex encoding
+  t.equal(Buffer.from(b.toString('hex'), 'hex').indexOf('64', 0, 'hex'), 3)
   t.equal(
-    Buffer.from(b.toString('hex'), 'hex')
-      .indexOf('64', 0, 'hex'),
-    3
-  )
-  t.equal(
-    Buffer.from(b.toString('hex'), 'hex')
-      .indexOf(Buffer.from('64', 'hex'), 0, 'hex'),
+    Buffer.from(b.toString('hex'), 'hex').indexOf(
+      Buffer.from('64', 'hex'),
+      0,
+      'hex'
+    ),
     3
   )
 
   // test base64 encoding
   t.equal(
-    Buffer.from(b.toString('base64'), 'base64')
-      .indexOf('ZA==', 0, 'base64'),
+    Buffer.from(b.toString('base64'), 'base64').indexOf('ZA==', 0, 'base64'),
     3
   )
   t.equal(
-    Buffer.from(b.toString('base64'), 'base64')
-      .indexOf(Buffer.from('ZA==', 'base64'), 0, 'base64'),
+    Buffer.from(b.toString('base64'), 'base64').indexOf(
+      Buffer.from('ZA==', 'base64'),
+      0,
+      'base64'
+    ),
     3
   )
 
   // test ascii encoding
+  t.equal(Buffer.from(b.toString('ascii'), 'ascii').indexOf('d', 0, 'ascii'), 3)
   t.equal(
-    Buffer.from(b.toString('ascii'), 'ascii')
-      .indexOf('d', 0, 'ascii'),
-    3
-  )
-  t.equal(
-    Buffer.from(b.toString('ascii'), 'ascii')
-      .indexOf(Buffer.from('d', 'ascii'), 0, 'ascii'),
+    Buffer.from(b.toString('ascii'), 'ascii').indexOf(
+      Buffer.from('d', 'ascii'),
+      0,
+      'ascii'
+    ),
     3
   )
 
@@ -260,24 +285,28 @@ tape('indexOf the entire nodejs10 buffer test suite', (t) => {
     t.equal(8, twoByteString.indexOf('\u0395', 4, 'ucs2'))
     t.equal(6, twoByteString.indexOf('\u03a3', -4, 'ucs2'))
     t.equal(4, twoByteString.indexOf('\u03a3', -6, 'ucs2'))
-    t.equal(4, twoByteString.indexOf(
-      Buffer.from('\u03a3', 'ucs2'), -6, 'ucs2'))
+    t.equal(4, twoByteString.indexOf(Buffer.from('\u03a3', 'ucs2'), -6, 'ucs2'))
     t.equal(-1, twoByteString.indexOf('\u03a3', -2, 'ucs2'))
   }
 
-  const mixedByteStringUcs2 =
-      Buffer.from('\u039a\u0391abc\u03a3\u03a3\u0395', 'ucs2')
+  const mixedByteStringUcs2 = Buffer.from(
+    '\u039a\u0391abc\u03a3\u03a3\u0395',
+    'ucs2'
+  )
 
   t.equal(6, mixedByteStringUcs2.indexOf('bc', 0, 'ucs2'))
   t.equal(10, mixedByteStringUcs2.indexOf('\u03a3', 0, 'ucs2'))
   t.equal(-1, mixedByteStringUcs2.indexOf('\u0396', 0, 'ucs2'))
 
+  t.equal(6, mixedByteStringUcs2.indexOf(Buffer.from('bc', 'ucs2'), 0, 'ucs2'))
   t.equal(
-    6, mixedByteStringUcs2.indexOf(Buffer.from('bc', 'ucs2'), 0, 'ucs2'))
+    10,
+    mixedByteStringUcs2.indexOf(Buffer.from('\u03a3', 'ucs2'), 0, 'ucs2')
+  )
   t.equal(
-    10, mixedByteStringUcs2.indexOf(Buffer.from('\u03a3', 'ucs2'), 0, 'ucs2'))
-  t.equal(
-    -1, mixedByteStringUcs2.indexOf(Buffer.from('\u0396', 'ucs2'), 0, 'ucs2'))
+    -1,
+    mixedByteStringUcs2.indexOf(Buffer.from('\u0396', 'ucs2'), 0, 'ucs2')
+  )
 
   {
     const twoByteString = Buffer.from('\u039a\u0391\u03a3\u03a3\u0395', 'ucs2')
@@ -317,7 +346,8 @@ tape('indexOf the entire nodejs10 buffer test suite', (t) => {
   // Test complex string indexOf algorithms. Only trigger for long strings.
   // Long string that isn't a simple repeat of a shorter string.
   let longString = 'A'
-  for (let i = 66; i < 76; i++) { // from 'B' to 'K'
+  for (let i = 66; i < 76; i++) {
+    // from 'B' to 'K'
     longString = longString + String.fromCharCode(i) + longString
   }
 
@@ -327,8 +357,7 @@ tape('indexOf the entire nodejs10 buffer test suite', (t) => {
   let pattern = 'ABACABADABACABA'
   for (let i = 0; i < longBufferString.length - pattern.length; i += 7) {
     const index = longBufferString.indexOf(pattern, i)
-    t.equal((i + 15) & ~0xf, index,
-      `Long ABACABA...-string at index ${i}`)
+    t.equal((i + 15) & ~0xf, index, `Long ABACABA...-string at index ${i}`)
   }
 
   let index = longBufferString.indexOf('AJABACA')
@@ -340,12 +369,10 @@ tape('indexOf the entire nodejs10 buffer test suite', (t) => {
   index = longBufferString.indexOf(pattern)
   t.equal(511, index, `Long JABACABA..., First J - at index ${index}`)
   index = longBufferString.indexOf(pattern, 512)
-  t.equal(
-    1535, index, `Long JABACABA..., Second J - at index ${index}`)
+  t.equal(1535, index, `Long JABACABA..., Second J - at index ${index}`)
 
   // Search for a non-ASCII string in a pure ASCII string.
-  const asciiString = Buffer.from(
-    'somethingnotatallsinisterwhichalsoworks')
+  const asciiString = Buffer.from('somethingnotatallsinisterwhichalsoworks')
   t.equal(-1, asciiString.indexOf('\x2061'))
   t.equal(3, asciiString.indexOf('eth', 0))
 
@@ -376,25 +403,28 @@ tape('indexOf the entire nodejs10 buffer test suite', (t) => {
   {
     // Find substrings in Utf8.
     const lengths = [1, 3, 15] // Single char, simple and complex.
-    const indices = [0x5, 0x60, 0x400, 0x680, 0x7ee, 0xFF02, 0x16610, 0x2f77b]
+    const indices = [0x5, 0x60, 0x400, 0x680, 0x7ee, 0xff02, 0x16610, 0x2f77b]
     for (let lengthIndex = 0; lengthIndex < lengths.length; lengthIndex++) {
       for (let i = 0; i < indices.length; i++) {
         const index = indices[i]
         let length = lengths[lengthIndex]
 
-        if (index + length > 0x7F) {
+        if (index + length > 0x7f) {
           length = 2 * length
         }
 
-        if (index + length > 0x7FF) {
+        if (index + length > 0x7ff) {
           length = 3 * length
         }
 
-        if (index + length > 0xFFFF) {
+        if (index + length > 0xffff) {
           length = 4 * length
         }
 
-        const patternBufferUtf8 = allCharsBufferUtf8.slice(index, index + length)
+        const patternBufferUtf8 = allCharsBufferUtf8.slice(
+          index,
+          index + length
+        )
         t.equal(index, allCharsBufferUtf8.indexOf(patternBufferUtf8))
 
         const patternStringUtf8 = patternBufferUtf8.toString()
@@ -413,24 +443,24 @@ tape('indexOf the entire nodejs10 buffer test suite', (t) => {
         const index = indices[i] * 2
         const length = lengths[lengthIndex]
 
-        const patternBufferUcs2 =
-            allCharsBufferUcs2.slice(index, index + length)
-        t.equal(
-          index, allCharsBufferUcs2.indexOf(patternBufferUcs2, 0, 'ucs2'))
+        const patternBufferUcs2 = allCharsBufferUcs2.slice(
+          index,
+          index + length
+        )
+        t.equal(index, allCharsBufferUcs2.indexOf(patternBufferUcs2, 0, 'ucs2'))
 
         const patternStringUcs2 = patternBufferUcs2.toString('ucs2')
-        t.equal(
-          index, allCharsBufferUcs2.indexOf(patternStringUcs2, 0, 'ucs2'))
+        t.equal(index, allCharsBufferUcs2.indexOf(patternStringUcs2, 0, 'ucs2'))
       }
     }
   }
 
-  [
-    () => {},
-    {},
-    []
-  ].forEach((val) => {
-    t.throws(() => b.indexOf(val), TypeError, `"${JSON.stringify(val)}" should throw`)
+  ;[() => {}, {}, []].forEach((val) => {
+    t.throws(
+      () => b.indexOf(val),
+      TypeError,
+      `"${JSON.stringify(val)}" should throw`
+    )
   })
 
   // Test weird offset arguments.
@@ -445,24 +475,12 @@ tape('indexOf the entire nodejs10 buffer test suite', (t) => {
   t.equal(b.indexOf('b', [2]), -1)
 
   // Behavior should match String.indexOf()
-  t.equal(
-    b.indexOf('b', undefined),
-    stringComparison.indexOf('b', undefined))
-  t.equal(
-    b.indexOf('b', {}),
-    stringComparison.indexOf('b', {}))
-  t.equal(
-    b.indexOf('b', 0),
-    stringComparison.indexOf('b', 0))
-  t.equal(
-    b.indexOf('b', null),
-    stringComparison.indexOf('b', null))
-  t.equal(
-    b.indexOf('b', []),
-    stringComparison.indexOf('b', []))
-  t.equal(
-    b.indexOf('b', [2]),
-    stringComparison.indexOf('b', [2]))
+  t.equal(b.indexOf('b', undefined), stringComparison.indexOf('b', undefined))
+  t.equal(b.indexOf('b', {}), stringComparison.indexOf('b', {}))
+  t.equal(b.indexOf('b', 0), stringComparison.indexOf('b', 0))
+  t.equal(b.indexOf('b', null), stringComparison.indexOf('b', null))
+  t.equal(b.indexOf('b', []), stringComparison.indexOf('b', []))
+  t.equal(b.indexOf('b', [2]), stringComparison.indexOf('b', [2]))
 
   // test truncation of Number arguments to uint8
   {

--- a/test/isBufferList.js
+++ b/test/isBufferList.js
@@ -21,7 +21,7 @@ tape('isBufferList negatives', (t) => {
     {},
     [],
     Buffer.alloc(0),
-    [Buffer.alloc(0)]
+    [Buffer.alloc(0)],
   ]
 
   for (const obj of types) {

--- a/test/test.js
+++ b/test/test.js
@@ -10,8 +10,12 @@ const BufferListStream = require('../')
 const { Buffer } = require('buffer')
 
 /**
+ * @typedef { { _bufs?: Buffer[] } } InternalBufferArray;
+ */
+
+/**
  * This typedef allows us to add _bufs to the API without declaring it publicly on types.
- * @typedef { BufferListStream & { _bufs?: Buffer[] }} BufferListStreamWithPrivate
+ * @typedef { BufferListStream & InternalBufferArray} BufferListStreamWithPrivate
  */
 
 /**
@@ -158,10 +162,10 @@ tape('multiple bytes from crazy nested buffer lists', function (t) {
       new BufferListStream([
         new BufferListStream(Buffer.from('abc')),
         Buffer.from('d'),
-        new BufferListStream(Buffer.from('efg'))
+        new BufferListStream(Buffer.from('efg')),
       ]),
       new BufferListStream([Buffer.from('hi')]),
-      new BufferListStream(Buffer.from('j'))
+      new BufferListStream(Buffer.from('j')),
     ])
   )
 
@@ -196,7 +200,11 @@ tape('append accepts arrays of Uint8Arrays', function (t) {
   bl.append(new Uint8Array([97, 98, 99]))
   bl.append([Uint8Array.from([100, 101, 102])])
   bl.append([new Uint8Array([103, 104, 105]), new Uint8Array([106, 107, 108])])
-  bl.append([new Uint8Array([109, 110, 111, 112]), new Uint8Array([113, 114, 115, 116, 117]), new Uint8Array([118, 119, 120, 121, 122])])
+  bl.append([
+    new Uint8Array([109, 110, 111, 112]),
+    new Uint8Array([113, 114, 115, 116, 117]),
+    new Uint8Array([118, 119, 120, 121, 122]),
+  ])
   t.equal(bl.length, 26)
   t.equal(bl.slice().toString('ascii'), 'abcdefghijklmnopqrstuvwxyz')
 
@@ -213,7 +221,7 @@ tape('append accepts arrays of BufferLists', function (t) {
   )
   bl.append([
     Buffer.from('mnop'),
-    new BufferListStream([Buffer.from('qrstu'), Buffer.from('vwxyz')])
+    new BufferListStream([Buffer.from('qrstu'), Buffer.from('vwxyz')]),
   ])
   t.equal(bl.length, 26)
   t.equal(bl.slice().toString('ascii'), 'abcdefghijklmnopqrstuvwxyz')
@@ -240,7 +248,7 @@ tape('append chainable (test results)', function (t) {
     )
     .append([
       Buffer.from('mnop'),
-      new BufferListStream([Buffer.from('qrstu'), Buffer.from('vwxyz')])
+      new BufferListStream([Buffer.from('qrstu'), Buffer.from('vwxyz')]),
     ])
 
   t.equal(bl.length, 26)
@@ -328,65 +336,71 @@ tape('test readUInt8 / readInt8', function (t) {
   t.end()
 })
 
-tape('test readUInt16LE / readUInt16BE / readInt16LE / readInt16BE', function (t) {
-  const buf1 = Buffer.alloc(1)
-  const buf2 = Buffer.alloc(3)
-  const buf3 = Buffer.alloc(3)
-  const bl = new BufferListStream()
+tape(
+  'test readUInt16LE / readUInt16BE / readInt16LE / readInt16BE',
+  function (t) {
+    const buf1 = Buffer.alloc(1)
+    const buf2 = Buffer.alloc(3)
+    const buf3 = Buffer.alloc(3)
+    const bl = new BufferListStream()
 
-  buf1[0] = 0x1
-  buf2[1] = 0x3
-  buf2[2] = 0x4
-  buf3[0] = 0x23
-  buf3[1] = 0x42
+    buf1[0] = 0x1
+    buf2[1] = 0x3
+    buf2[2] = 0x4
+    buf3[0] = 0x23
+    buf3[1] = 0x42
 
-  bl.append(buf1)
-  bl.append(buf2)
-  bl.append(buf3)
+    bl.append(buf1)
+    bl.append(buf2)
+    bl.append(buf3)
 
-  t.equal(bl.readUInt16BE(), 0x0100)
-  t.equal(bl.readUInt16LE(), 0x0001)
-  t.equal(bl.readUInt16BE(2), 0x0304)
-  t.equal(bl.readUInt16LE(2), 0x0403)
-  t.equal(bl.readInt16BE(2), 0x0304)
-  t.equal(bl.readInt16LE(2), 0x0403)
-  t.equal(bl.readUInt16BE(3), 0x0423)
-  t.equal(bl.readUInt16LE(3), 0x2304)
-  t.equal(bl.readInt16BE(3), 0x0423)
-  t.equal(bl.readInt16LE(3), 0x2304)
-  t.equal(bl.readUInt16BE(4), 0x2342)
-  t.equal(bl.readUInt16LE(4), 0x4223)
-  t.equal(bl.readInt16BE(4), 0x2342)
-  t.equal(bl.readInt16LE(4), 0x4223)
+    t.equal(bl.readUInt16BE(), 0x0100)
+    t.equal(bl.readUInt16LE(), 0x0001)
+    t.equal(bl.readUInt16BE(2), 0x0304)
+    t.equal(bl.readUInt16LE(2), 0x0403)
+    t.equal(bl.readInt16BE(2), 0x0304)
+    t.equal(bl.readInt16LE(2), 0x0403)
+    t.equal(bl.readUInt16BE(3), 0x0423)
+    t.equal(bl.readUInt16LE(3), 0x2304)
+    t.equal(bl.readInt16BE(3), 0x0423)
+    t.equal(bl.readInt16LE(3), 0x2304)
+    t.equal(bl.readUInt16BE(4), 0x2342)
+    t.equal(bl.readUInt16LE(4), 0x4223)
+    t.equal(bl.readInt16BE(4), 0x2342)
+    t.equal(bl.readInt16LE(4), 0x4223)
 
-  t.end()
-})
+    t.end()
+  }
+)
 
-tape('test readUInt32LE / readUInt32BE / readInt32LE / readInt32BE', function (t) {
-  const buf1 = Buffer.alloc(1)
-  const buf2 = Buffer.alloc(3)
-  const buf3 = Buffer.alloc(3)
-  const bl = new BufferListStream()
+tape(
+  'test readUInt32LE / readUInt32BE / readInt32LE / readInt32BE',
+  function (t) {
+    const buf1 = Buffer.alloc(1)
+    const buf2 = Buffer.alloc(3)
+    const buf3 = Buffer.alloc(3)
+    const bl = new BufferListStream()
 
-  buf1[0] = 0x1
-  buf2[1] = 0x3
-  buf2[2] = 0x4
-  buf3[0] = 0x23
-  buf3[1] = 0x42
+    buf1[0] = 0x1
+    buf2[1] = 0x3
+    buf2[2] = 0x4
+    buf3[0] = 0x23
+    buf3[1] = 0x42
 
-  bl.append(buf1)
-  bl.append(buf2)
-  bl.append(buf3)
+    bl.append(buf1)
+    bl.append(buf2)
+    bl.append(buf3)
 
-  t.equal(bl.readUInt32BE(), 0x01000304)
-  t.equal(bl.readUInt32LE(), 0x04030001)
-  t.equal(bl.readUInt32BE(2), 0x03042342)
-  t.equal(bl.readUInt32LE(2), 0x42230403)
-  t.equal(bl.readInt32BE(2), 0x03042342)
-  t.equal(bl.readInt32LE(2), 0x42230403)
+    t.equal(bl.readUInt32BE(), 0x01000304)
+    t.equal(bl.readUInt32LE(), 0x04030001)
+    t.equal(bl.readUInt32BE(2), 0x03042342)
+    t.equal(bl.readUInt32LE(2), 0x42230403)
+    t.equal(bl.readInt32BE(2), 0x03042342)
+    t.equal(bl.readInt32LE(2), 0x42230403)
 
-  t.end()
-})
+    t.end()
+  }
+)
 
 tape('test readUIntLE / readUIntBE / readIntLE / readIntBE', function (t) {
   const buf1 = Buffer.alloc(1)
@@ -537,20 +551,24 @@ tape('uninitialized memory', function (t) {
   t.end()
 })
 
-!process.browser && tape('test stream', function (t) {
-  const random = crypto.randomBytes(65534)
+!process.browser &&
+  tape('test stream', function (t) {
+    const random = crypto.randomBytes(65534)
 
-  const bl = new BufferListStream((err, buf) => {
-    t.ok(Buffer.isBuffer(buf))
-    t.ok(err === null)
-    t.ok(random.equals(bl.slice()))
-    t.ok(random.equals(buf.slice()))
+    const bl = new BufferListStream((err, buf) => {
+      t.ok(Buffer.isBuffer(buf))
+      t.ok(err === null)
+      t.ok(random.equals(bl.slice()))
+      t.ok(random.equals(buf.slice()))
 
-    bl.pipe(fs.createWriteStream(path.join(os.tmpdir(), 'bl_test_rnd_out.dat')))
-      .on('close', function () {
+      bl.pipe(
+        fs.createWriteStream(path.join(os.tmpdir(), 'bl_test_rnd_out.dat'))
+      ).on('close', function () {
         const rndhash = crypto.createHash('md5').update(random).digest('hex')
         const md5sum = crypto.createHash('md5')
-        const s = fs.createReadStream(path.join(os.tmpdir(), 'bl_test_rnd_out.dat'))
+        const s = fs.createReadStream(
+          path.join(os.tmpdir(), 'bl_test_rnd_out.dat')
+        )
 
         s.on('data', md5sum.update.bind(md5sum))
         s.on('end', function () {
@@ -558,11 +576,11 @@ tape('uninitialized memory', function (t) {
           t.end()
         })
       })
-  })
+    })
 
-  fs.writeFileSync(path.join(os.tmpdir(), 'bl_test_rnd.dat'), random)
-  fs.createReadStream(path.join(os.tmpdir(), 'bl_test_rnd.dat')).pipe(bl)
-})
+    fs.writeFileSync(path.join(os.tmpdir(), 'bl_test_rnd.dat'), random)
+    fs.createReadStream(path.join(os.tmpdir(), 'bl_test_rnd.dat')).pipe(bl)
+  })
 
 tape('instantiation with Buffer', function (t) {
   const buf = crypto.randomBytes(1024)
@@ -571,7 +589,11 @@ tape('instantiation with Buffer', function (t) {
 
   t.equal(buf.toString('hex'), b.slice().toString('hex'), 'same buffer')
   b = BufferListStream([buf, buf2])
-  t.equal(b.slice().toString('hex'), Buffer.concat([buf, buf2]).toString('hex'), 'same buffer')
+  t.equal(
+    b.slice().toString('hex'),
+    Buffer.concat([buf, buf2]).toString('hex'),
+    'same buffer'
+  )
 
   t.end()
 })
@@ -676,7 +698,11 @@ tape('copy at a precise position', function (t) {
   const b = BufferListStream(buf)
 
   b.copy(buf2, 20)
-  t.equal(b.slice().toString('hex'), buf2.slice(20).toString('hex'), 'same buffer')
+  t.equal(
+    b.slice().toString('hex'),
+    buf2.slice(20).toString('hex'),
+    'same buffer'
+  )
 
   t.end()
 })
@@ -762,7 +788,11 @@ tape('shallow slice with negative or omitted indices', function (t) {
 tape('shallow slice does not make a copy', function (t) {
   t.plan(1)
 
-  const buffers = [Buffer.from('First'), Buffer.from('Second'), Buffer.from('Third')]
+  const buffers = [
+    Buffer.from('First'),
+    Buffer.from('Second'),
+    Buffer.from('Third'),
+  ]
   const bl = new BufferListStream(buffers).shallowSlice(5, -3)
 
   buffers[1].fill('h')
@@ -774,8 +804,12 @@ tape('shallow slice does not make a copy', function (t) {
 tape('shallow slice with 0 length', function (t) {
   t.plan(1)
 
-  const buffers = [Buffer.from('First'), Buffer.from('Second'), Buffer.from('Third')]
-  const bl = (new BufferListStream(buffers)).shallowSlice(0, 0)
+  const buffers = [
+    Buffer.from('First'),
+    Buffer.from('Second'),
+    Buffer.from('Third'),
+  ]
+  const bl = new BufferListStream(buffers).shallowSlice(0, 0)
 
   t.equal(bl.length, 0)
 })
@@ -783,8 +817,12 @@ tape('shallow slice with 0 length', function (t) {
 tape('shallow slice with 0 length from middle', function (t) {
   t.plan(1)
 
-  const buffers = [Buffer.from('First'), Buffer.from('Second'), Buffer.from('Third')]
-  const bl = (new BufferListStream(buffers)).shallowSlice(10, 10)
+  const buffers = [
+    Buffer.from('First'),
+    Buffer.from('Second'),
+    Buffer.from('Third'),
+  ]
+  const bl = new BufferListStream(buffers).shallowSlice(10, 10)
 
   t.equal(bl.length, 0)
 })
@@ -827,88 +865,93 @@ tape('destroy with error', function (t) {
   t.equal(bl.length, 0)
 })
 
-!process.browser && tape('destroy with pipe before read end', function (t) {
-  t.plan(2)
+!process.browser &&
+  tape('destroy with pipe before read end', function (t) {
+    t.plan(2)
 
-  /** @type {BufferListStreamWithPrivate} */
-  const bl = new BufferListStream()
-  fs.createReadStream(path.join(__dirname, '/test.js'))
-    .pipe(bl)
+    /** @type {BufferListStreamWithPrivate} */
+    const bl = new BufferListStream()
+    fs.createReadStream(path.join(__dirname, '/test.js')).pipe(bl)
 
-  bl.destroy()
-
-  t.equal(bl._bufs.length, 0)
-  t.equal(bl.length, 0)
-})
-
-!process.browser && tape('destroy with pipe before read end with race', function (t) {
-  t.plan(2)
-
-  /** @type {BufferListStreamWithPrivate} */
-  const bl = new BufferListStream()
-
-  fs.createReadStream(path.join(__dirname, '/test.js'))
-    .pipe(bl)
-
-  setTimeout(function () {
-    bl.destroy()
-    setTimeout(function () {
-      t.equal(bl._bufs.length, 0)
-      t.equal(bl.length, 0)
-    }, 500)
-  }, 500)
-})
-
-!process.browser && tape('destroy with pipe after read end', function (t) {
-  t.plan(2)
-
-  /** @type {BufferListStreamWithPrivate} */
-  const bl = new BufferListStream()
-  fs.createReadStream(path.join(__dirname, '/test.js'))
-    .on('end', onEnd)
-    .pipe(bl)
-
-  function onEnd () {
     bl.destroy()
 
     t.equal(bl._bufs.length, 0)
     t.equal(bl.length, 0)
-  }
-})
+  })
 
-!process.browser && tape('destroy with pipe while writing to a destination', function (t) {
-  t.plan(4)
+!process.browser &&
+  tape('destroy with pipe before read end with race', function (t) {
+    t.plan(2)
 
-  /** @type {BufferListStreamWithPrivate} */
-  const bl = new BufferListStream()
-  const ds = new BufferListStream()
+    /** @type {BufferListStreamWithPrivate} */
+    const bl = new BufferListStream()
 
-  fs.createReadStream(path.join(__dirname, '/test.js'))
-    .on('end', onEnd)
-    .pipe(bl)
-
-  function onEnd () {
-    bl.pipe(ds)
+    fs.createReadStream(path.join(__dirname, '/test.js')).pipe(bl)
 
     setTimeout(function () {
       bl.destroy()
+      setTimeout(function () {
+        t.equal(bl._bufs.length, 0)
+        t.equal(bl.length, 0)
+      }, 500)
+    }, 500)
+  })
 
-      t.equals(bl._bufs.length, 0)
-      t.equals(bl.length, 0)
+!process.browser &&
+  tape('destroy with pipe after read end', function (t) {
+    t.plan(2)
 
-      ds.destroy()
+    /** @type {BufferListStreamWithPrivate} */
+    const bl = new BufferListStream()
+    fs.createReadStream(path.join(__dirname, '/test.js'))
+      .on('end', onEnd)
+      .pipe(bl)
 
-      t.equals(bl._bufs.length, 0)
-      t.equals(bl.length, 0)
-    }, 100)
-  }
-})
+    function onEnd() {
+      bl.destroy()
 
-!process.browser && tape('handle error', function (t) {
-  t.plan(2)
+      t.equal(bl._bufs.length, 0)
+      t.equal(bl.length, 0)
+    }
+  })
 
-  fs.createReadStream('/does/not/exist').pipe(BufferListStream(function (err, data) {
-    t.ok(err instanceof Error, 'has error')
-    t.notOk(data, 'no data')
-  }))
-})
+!process.browser &&
+  tape('destroy with pipe while writing to a destination', function (t) {
+    t.plan(4)
+
+    /** @type {BufferListStreamWithPrivate} */
+    const bl = new BufferListStream()
+    const ds = new BufferListStream()
+
+    fs.createReadStream(path.join(__dirname, '/test.js'))
+      .on('end', onEnd)
+      .pipe(bl)
+
+    function onEnd() {
+      bl.pipe(ds)
+
+      setTimeout(function () {
+        bl.destroy()
+
+        t.equals(bl._bufs.length, 0)
+        t.equals(bl.length, 0)
+
+        ds.destroy()
+
+        t.equals(bl._bufs.length, 0)
+        t.equals(bl.length, 0)
+      }, 100)
+    }
+  })
+
+!process.browser &&
+  tape('handle error', function (t) {
+    t.plan(2)
+
+    fs.createReadStream('/does/not/exist').pipe(
+      BufferListStream(function (err, data) {
+        t.ok(err instanceof Error, 'has error')
+        t.notOk(data, 'no data')
+      })
+    )
+  })


### PR DESCRIPTION
Hey @rvagg, I know that in #108 we said to add a `.editorconfig` file, but sadly its options are limited for Javascript (for example, semi-colons). So I opted in for prettier to achieve better results.

I hope this will be still appreciated!

Let me know!


EDIT: Oh, I'm seeing right now that this seems to conflict with Standardjs checks 😳.
It seems that it would be required to use `ts-standard` to format in the same way also typescript declarations 🤔 What should I do with this PR? Keep it, change to `ts-standard` o what else?