### PR TITLE
make @types/readable-stream a standard dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,12 +28,12 @@
     "awesomesauce"
   ],
   "dependencies": {
+    "@types/readable-stream": "^4.0.0",
     "buffer": "^6.0.3",
     "inherits": "^2.0.4",
     "readable-stream": "^4.2.0"
   },
   "devDependencies": {
-    "@types/readable-stream": "^4.0.0",
     "faucet": "~0.0.1",
     "standard": "^17.0.0",
     "tape": "^5.2.2",


### PR DESCRIPTION
The builtin types reference `@types/readable-stream` but don't include it as a dependency (it's currently in devDependencies) meaning consumers of this package must explicitly include `@types/readable-stream` in their own dependencies for types to resolve properly. Without this fix, `tsc` gives errors like the following:

```
  Overload 1 of 7, '(source: Readable, destination: WritableStream | PipelineDestinationIterableFunction<any> | PipelineDestinationPromiseFunction<any, any>, options?: PipelineOptions | undefined): Promise<...> | Promise<...>', gave the following error.
    Argument of type 'BufferListStream' is not assignable to parameter of type 'WritableStream | PipelineDestinationIterableFunction<any> | PipelineDestinationPromiseFunction<any, any>'.
  Overload 2 of 7, '(streams: readonly (WritableStream | ReadableStream | ReadWriteStream)[], options?: PipelineOptions | undefined): Promise<...>', gave the following error.
    Argument of type 'Readable' is not assignable to parameter of type 'readonly (WritableStream | ReadableStream | ReadWriteStream)[]'.
      Type 'Readable' is missing the following properties from type 'readonly (WritableStream | ReadableStream | ReadWriteStream)[]': length, concat, join, slice, and 19 more.
  Overload 3 of 7, '(stream1: ReadableStream, stream2: WritableStream | ReadWriteStream, ...streams: (WritableStream | ReadWriteStream | PipelineOptions)[]): Promise<...>', gave the following error.
    Argument of type 'BufferListStream' is not assignable to parameter of type 'WritableStream | ReadWriteStream'.
```

Moving type dependencies into `dependencies` matches the guidance in Typescript docs https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#dependencies
> Make sure all the declaration packages you depend on are marked appropriately in the "dependencies" section in your package.json. For example, imagine we authored a package that used Browserify and TypeScript. [...] browserify does not bundle its declaration files with its npm packages, so we needed to depend on @types/browserify for its declarations.