### PR TITLE
chore(deps): remove unnecessary dependency on buffer

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
   ],
   "dependencies": {
     "@types/readable-stream": "^4.0.0",
-    "buffer": "^6.0.3",
     "inherits": "^2.0.4",
     "readable-stream": "^4.2.0"
   },


### PR DESCRIPTION
Node.js provides a built-in buffer module which is what this package actually uses there.
The buffer package is meant to be used in the browser which, as far as I can tell, is not supported.