### PR TITLE
Move @types/readable-stream to devDependencies Fixes #145

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,12 +28,12 @@
     "awesomesauce"
   ],
   "dependencies": {
-    "@types/readable-stream": "^4.0.0",
     "buffer": "^6.0.3",
     "inherits": "^2.0.4",
     "readable-stream": "^4.2.0"
   },
   "devDependencies": {
+    "@types/readable-stream": "^4.0.0",
     "faucet": "~0.0.1",
     "standard": "^17.0.0",
     "tape": "^5.2.2",


### PR DESCRIPTION
This should fix an upstream dependency issue that Tedious is having with TypeScript and the location of this dependency.