### PR TITLE
test: ignore TS errors from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lint": "standard *.js test/*.js",
     "test": "npm run lint && npm run test:types && node test/test.js | faucet",
     "test:ci": "npm run lint && node test/test.js && npm run test:types",
-    "test:types": "tsc --target esnext --moduleResolution node --allowJs --noEmit test/test.js",
+    "test:types": "tsc --target esnext --moduleResolution node --allowJs --noEmit --skipLibCheck test/test.js",
     "build": "true"
   },
   "repository": {


### PR DESCRIPTION
Silences an error coming from `@types/readable-stream`, which cannot be fixed in this package.
