### PR TITLE
cleanup: use shields.io for CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # bl *(BufferList)*
 
-[![Build Status](https://api.travis-ci.com/rvagg/bl.svg?branch=master)](https://travis-ci.com/rvagg/bl/)
+![Build Status](https://img.shields.io/github/actions/workflow/status/rvagg/bl/test-and-release.yml?branch=master)
 
 **A Node.js Buffer list collector, reader and streamer thingy.**
 


### PR DESCRIPTION
<details>

<summary>EDIT: commit introducing `.npmignore` is now reverted</summary>

I noticed a few extra files in your npm package, so I took the initiative to cleanup a little.



<img width="200" alt="Screenshot 2025-02-04 at 11 11 40" src="https://github.com/user-attachments/assets/518230d0-40ef-4e06-846a-0be6a553053e" />

## .npmignore

* https://docs.npmjs.com/cli/v9/using-npm/developers#keeping-files-out-of-your-package

⚠️ This felt like a simple change and is untested
⚠️ An alternate is an allowlist approach using `files` in `package.json`

</details>

## Badge

* Travis was removed in https://github.com/rvagg/bl/pull/110 (https://github.com/rvagg/bl/commit/387dfaf9b2bca7849f12785436ceb01e42adac2c)
* shields.io docs - https://shields.io/badges/git-hub-actions-workflow-status

The change is visible: https://github.com/david-allison/bl

----
**Updated badge (visually unchanged):**
<img width="857" alt="Screenshot 2025-02-04 at 11 30 13" src="https://github.com/user-attachments/assets/abac988d-9462-4159-a805-8fdc93fcc573" />