### PR TITLE
fix(ts): type definitions are not resolvable without proper types fields in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,10 +8,11 @@
     "node": ">=20"
   },
   "main": "./BufferListStream.js",
+  "types": "./types/index.d.ts",
   "exports": {
     ".": {
-      "import": "./BufferListStream.js",
-      "types": "./types/index.d.ts"
+      "types": "./types/index.d.ts",
+      "import": "./BufferListStream.js"
     }
   },
   "scripts": {
@@ -39,13 +40,13 @@
     "awesomesauce"
   ],
   "devDependencies": {
-    "@types/node": "^25.0.0",
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/commit-analyzer": "^13.0.1",
     "@semantic-release/git": "^10.0.1",
     "@semantic-release/github": "^12.0.6",
     "@semantic-release/npm": "^13.1.5",
     "@semantic-release/release-notes-generator": "^14.1.0",
+    "@types/node": "^25.0.0",
     "conventional-changelog-conventionalcommits": "^9.3.0",
     "faucet": "^0.0.4",
     "semantic-release": "^25.0.3",

--- a/package.json
+++ b/package.json
@@ -40,13 +40,13 @@
     "awesomesauce"
   ],
   "devDependencies": {
+    "@types/node": "^25.0.0",
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/commit-analyzer": "^13.0.1",
     "@semantic-release/git": "^10.0.1",
     "@semantic-release/github": "^12.0.6",
     "@semantic-release/npm": "^13.1.5",
     "@semantic-release/release-notes-generator": "^14.1.0",
-    "@types/node": "^25.0.0",
     "conventional-changelog-conventionalcommits": "^9.3.0",
     "faucet": "^0.0.4",
     "semantic-release": "^25.0.3",


### PR DESCRIPTION
Hi! It seems like the type definitions are not importable in the current release just because of these small quirks about how you have to put the `"types"` fields in the package.json. 

Here's a site that provides a test: 

https://arethetypeswrong.github.io/?p=bl%407.0.0